### PR TITLE
Use pip instead of easy_install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,9 +19,9 @@ Download
 
 Github: http://github.com/rbarrois/factory_boy/
 
-easy_install::
+PyPI::
 
-    easy_install factory_boy
+    pip install factory_boy
 
 Source::
 


### PR DESCRIPTION
easy_install is old hat now (and bad), pip is the logical evolution.
