### PR TITLE
Switch `sorted` argument from `cmp` to `key`.

### DIFF
--- a/factory/utils.py
+++ b/factory/utils.py
@@ -57,16 +57,6 @@ def extract_dict(prefix, kwargs, pop=True, exclude=()):
     return extracted
 
 
-def declength_compare(a, b):
-    """Compare objects, choosing longest first."""
-    if len(a) > len(b):
-        return -1
-    elif len(a) < len(b):
-        return 1
-    else:
-        return cmp(a, b)
-
-
 def multi_extract_dict(prefixes, kwargs, pop=True, exclude=()):
     """Extracts all values from a given list of prefixes.
 
@@ -78,7 +68,7 @@ def multi_extract_dict(prefixes, kwargs, pop=True, exclude=()):
     """
     results = {}
     exclude = list(exclude)
-    for prefix in sorted(prefixes, cmp=declength_compare):
+    for prefix in sorted(prefixes, key=lambda x: -len(x)):
         extracted = extract_dict(prefix, kwargs, pop=pop, exclude=exclude)
         results[prefix] = extracted
         exclude.extend(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,24 +25,6 @@ from factory import utils
 
 from .compat import unittest
 
-class DecLengthCompareTestCase(unittest.TestCase):
-    def test_reciprocity(self):
-        self.assertEqual(1, utils.declength_compare('a', 'bb'))
-        self.assertEqual(-1, utils.declength_compare('aa', 'b'))
-
-    def test_not_lexical(self):
-        self.assertEqual(1, utils.declength_compare('abc', 'aaaa'))
-        self.assertEqual(-1, utils.declength_compare('aaaa', 'abc'))
-
-    def test_same_length(self):
-        self.assertEqual(-1, utils.declength_compare('abc', 'abd'))
-        self.assertEqual(1, utils.declength_compare('abe', 'abd'))
-
-    def test_equality(self):
-        self.assertEqual(0, utils.declength_compare('abc', 'abc'))
-        self.assertEqual(0, utils.declength_compare([1, 2, 3], [1, 2, 3]))
-
-
 class ExtractDictTestCase(unittest.TestCase):
     def test_empty_dict(self):
         self.assertEqual({}, utils.extract_dict('foo', {}))


### PR DESCRIPTION
Pulled 'cmp => key' improvement out of #20.
