### PR TITLE
Adds override_strategy decorator/context manager

### DIFF
--- a/factory/base.py
+++ b/factory/base.py
@@ -20,9 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from __future__ import with_statement
+
 import re
 import sys
 import warnings
+from functools import wraps
 
 from factory import containers
 
@@ -651,3 +654,26 @@ def use_strategy(new_strategy):
         klass.default_strategy = new_strategy
         return klass
     return wrapped_class
+
+
+class override_strategy(object):
+    """
+    Temporarily overrides the default_strategy for initializing
+    factories. Acts as either a decorator or a context manager.
+    """
+    def __init__(self, strategy):
+        self.strategy = strategy
+
+    def __call__(self, func):
+        @wraps(func)
+        def wrap(*args, **kwargs):
+            with self:
+                return func(*args, **kwargs)
+        return wrap
+
+    def __enter__(self):
+        self._original_strategy = Factory.default_strategy
+        Factory.default_strategy = self.strategy
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        Factory.default_strategy = self._original_strategy

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -149,6 +149,24 @@ class FactoryDefaultStrategyTestCase(unittest.TestCase):
 
         self.assertEqual(base.CREATE_STRATEGY, TestModelFactory.default_strategy)
 
+    def test_override_strategy_context_manager(self):
+        before = base.Factory.default_strategy
+
+        with base.override_strategy(base.BUILD_STRATEGY):
+            self.assertEqual(base.BUILD_STRATEGY, base.Factory.default_strategy)
+
+        self.assertEqual(before, base.Factory.default_strategy)
+
+    def test_override_strategy_decorator(self):
+        before = base.Factory.default_strategy
+
+        @base.override_strategy(base.BUILD_STRATEGY)
+        def inner_test():
+            self.assertEqual(base.BUILD_STRATEGY, base.Factory.default_strategy)
+        inner_test()
+
+        self.assertEqual(before, base.Factory.default_strategy)
+
 
 class FactoryCreationTestCase(unittest.TestCase):
     def testFactoryFor(self):


### PR DESCRIPTION
This allows overriding the default_strategy for either a whole test function, or just a specific context.
