### PR TITLE
py3k compatibility via six (re-issue)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
 language: python
+
 python:
   - "2.6"
   - "2.7"
-script: "python setup.py test"
-install: "if [[ $TRAVIS_PYTHON_VERSION = 2.6 ]]; then pip install unittest2 --use-mirrors; fi"
+  - "3.2"
+  - "3.3"
+
+script:
+  - python setup.py test
+
+install: 
+  - pip install six
+  - "if [[ $TRAVIS_PYTHON_VERSION = 2.6 ]]; then pip install unittest2 --use-mirrors; fi"
+
 notifications:
   email: false
-  irc: "irc.freenode.org#factory_boy"

--- a/factory/base.py
+++ b/factory/base.py
@@ -23,7 +23,7 @@
 import re
 import sys
 import warnings
-
+import six
 from factory import containers
 
 # Strategies
@@ -45,7 +45,11 @@ CLASS_ATTRIBUTE_ASSOCIATED_CLASS = '_associated_class'
 
 def get_factory_bases(bases):
     """Retrieve all BaseFactoryMetaClass-derived bases from a list."""
-    return [b for b in bases if isinstance(b, BaseFactoryMetaClass)]
+    try:
+        return [b for b in bases if issubclass(b, Factory)]
+    except NameError:
+        # We are defining Factory itself here
+        return None
 
 
 class BaseFactoryMetaClass(type):
@@ -436,19 +440,17 @@ class BaseFactory(object):
         return cls.generate_batch(strategy, size, **kwargs)
 
 
-class StubFactory(BaseFactory):
-    __metaclass__ = BaseFactoryMetaClass
+class StubFactory(six.with_metaclass(BaseFactoryMetaClass, BaseFactory)):
 
     default_strategy = STUB_STRATEGY
 
 
-class Factory(BaseFactory):
+class Factory(six.with_metaclass(FactoryMetaClass, BaseFactory)):
     """Factory base with build and create support.
 
     This class has the ability to support multiple ORMs by using custom creation
     functions.
     """
-    __metaclass__ = FactoryMetaClass
 
     default_strategy = CREATE_STRATEGY
 

--- a/factory/declarations.py
+++ b/factory/declarations.py
@@ -24,7 +24,7 @@
 import collections
 import itertools
 import warnings
-
+import six
 from factory import utils
 
 
@@ -294,7 +294,7 @@ class SubFactory(ParameteredAttribute):
             self.factory_module = self.factory_name = ''
         else:
             # Must be a string
-            if not isinstance(factory, basestring) or '.' not in factory:
+            if not isinstance(factory, six.string_types) or '.' not in factory:
                 raise ValueError(
                         "The argument of a SubFactory must be either a class "
                         "or the fully qualified path to a Factory class; got "
@@ -393,7 +393,7 @@ class RelatedFactory(PostGenerationDeclaration):
             self.factory_module = self.factory_name = ''
         else:
             # Must be a string
-            if not isinstance(factory, basestring) or '.' not in factory:
+            if not isinstance(factory, six.string_types) or '.' not in factory:
                 raise ValueError(
                         "The argument of a SubFactory must be either a class "
                         "or the fully qualified path to a Factory class; got "

--- a/factory/utils.py
+++ b/factory/utils.py
@@ -43,7 +43,8 @@ def extract_dict(prefix, kwargs, pop=True, exclude=()):
     """
     prefix = prefix + ATTR_SPLITTER
     extracted = {}
-    for key in kwargs.keys():
+    
+    for key in list(kwargs):
         if key in exclude:
             continue
 

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -30,7 +30,7 @@ try:
 except ImportError:
     import unittest
 
-if is_python2:
+if sys.version_info[0:2] < (3, 3):
     import mock
 else:
     from unittest import mock


### PR DESCRIPTION
Had to close the prior pull request (#43) and reissue - think I screwed up trying to merge in your latest changes to keep the pull-request compatible.

I've made a changes to get the all tests passing for python **2.6**, **2.7**, **3.2** and **3.3**.  

**The actual code changes, as you'll see, are almost trivial and do not require any re-org of the files.**  The change does require the inclusion of the `six` library, which means a dependency.

I didn't change `setup.py` to include `six` in `install_requires` at this point.  I simply added it to the travis.yml file, so the tests would have it.  If this pull request is the direction you want to go with, I'll be happy to update it and include it.

Also, saw this commit in Django, which looks to provide the ability to subclass and specify a metaclass supporting both `__metaclass__` for py2 and with `six`:
https://github.com/django/django/commit/6b03179e126d4df01623dccc162c1579f349e41e
Might want to include that if you think people with want to subclass with custom metaclasses.

By the way, awesome work on this project. And the recent changes to the docs are great.
