### PR TITLE
Fixed reference.rst for birthdate timedelta() example.

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -672,7 +672,7 @@ That declaration takes a single argument, a dot-delimited path to the attribute 
     class UserFactory(factory.Factory)
         FACTORY_FOR = User
 
-        birthdate = factory.Sequence(lambda n: datetime.date(2000, 1, 1) + datetime.timedelta(days=n))
+        birthdate = factory.Sequence(lambda n: datetime.date(2000, 1, 1) + datetime.timedelta(days=int(n)))
         birthmonth = factory.SelfAttribute('birthdate.month')
 
 .. code-block:: pycon


### PR DESCRIPTION
"n" is a string.  Without converting it to an int, timedelta() raises an exception:
      TypeError: unsupported type for timedelta days component: str
