### PR TITLE
Fix example for factory.sequence decorator

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -99,7 +99,7 @@ This is achieved with the :class:`~factory.Sequence` declaration:
     >>> UserFactory()
     <User: user2>
 
-.. note:: For more complex situations, you may also use the :meth:`~factory.@sequence` decorator:
+.. note:: For more complex situations, you may also use the :meth:`~factory.@sequence` decorator (note that ``self`` is not added as first parameter):
 
           .. code-block:: python
 
@@ -107,7 +107,7 @@ This is achieved with the :class:`~factory.Sequence` declaration:
                 FACTORY_FOR = models.User
 
                 @factory.sequence
-                def username(self, n):
+                def username(n):
                     return 'user%d' % n
 
 


### PR DESCRIPTION
Example lists "self" as first parameter (but it should just accept single argument - n). Added also small note about it as well so people wouldn't get confused.
