### PR TITLE
Stop attempting to save mongoengine EmbeddedDocuments on creation

### DIFF
--- a/factory/mongoengine.py
+++ b/factory/mongoengine.py
@@ -41,5 +41,8 @@ class MongoEngineFactory(base.Factory):
     @classmethod
     def _create(cls, target_class, *args, **kwargs):
         instance = target_class(*args, **kwargs)
-        instance.save()
+        # If the document being created is an EmbeddedDocument subclass, it
+        # won't have a save method.
+        if hasattr(instance, "save"):
+            instance.save()
         return instance


### PR DESCRIPTION
In mongoengine EmbeddedDocuments are direct children of parent documents, and don't have a save method. As is stands, it isn't possible to create Documents which include EmbeddedDocument SubFactories, because the create propagates to the EmbeddedDocument and errors out.

Not sure on your take on the solution: I initially thought an elegant solution might be to allow a default mode of creation to be specified when defining the subfactory, but that creates problems too – because if the user does specify a non-default build strategy, then that strategy should, as a general rule, override it.
