### PR TITLE
use proper encoding when checking version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 import os
 import re
 import sys
+import codecs
 
 from setuptools import setup
 
@@ -14,7 +15,7 @@ def get_version(package_name):
     version_re = re.compile(r"^__version__ = [\"']([\w_.-]+)[\"']$")
     package_components = package_name.split('.')
     path_components = package_components + ['__init__.py']
-    with open(os.path.join(root_dir, *path_components)) as f:
+    with codecs.open(os.path.join(root_dir, *path_components), 'r', 'utf-8') as f:
         for line in f:
             match = version_re.match(line[:-1])
             if match:


### PR DESCRIPTION
The version is parsed incorrectly (without specifying encoding when parsing `__init__.py`) in setup.py.

Python version:

```
Python 3.3.3 (default, Dec 10 2013, 11:21:59)
[GCC 4.2.1 Compatible Apple LLVM 5.0 (clang-500.2.79)] on darwin
```

This is what happens when I try to install factory boy:

```
[py33] [master] ~/code/factory_boy $ python setup.py install
Traceback (most recent call last):
  File "setup.py", line 36, in <module>
    version=get_version(PACKAGE),
  File "setup.py", line 18, in get_version
    for line in f:
  File "/Users/andreas/.virtualenvs/py33/bin/../lib/python3.3/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 91: ordinal not in range(128)
```

The same issue exists when I try to install factory boy with pip from pypi:

```
[py33] $ pip --version
pip 1.4.1 from /Users/andreas/.virtualenvs/py33/lib/python3.3/site-packages (python 3.3)
[py33] $ pip install factory-boy
Downloading/unpacking factory-boy
  Using download cache from /Users/andreas/.pip_download_cache/https%3A%2F%2Fpypi.python.org%2Fpackages%2Fsource%2Ff%2Ffactory_boy%2Ffactory_boy-2.2.1.tar.gz
  Running setup.py egg_info for package factory-boy
    Traceback (most recent call last):
      File "<string>", line 16, in <module>
      File "/Users/andreas/.virtualenvs/py33/bin/../lib/python3.3/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1018: ordinal not in range(128)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 16, in <module>

  File "/Users/andreas/.virtualenvs/py33/bin/../lib/python3.3/encodings/ascii.py", line 26, in decode

    return codecs.ascii_decode(input, self.errors)[0]

UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1018: ordinal not in range(128)

----------------------------------------
Cleaning up...
Command python setup.py egg_info failed with error code 1 in /Users/andreas/.virtualenvs/py33/build/factory-boy
Storing complete log in /Users/andreas/.pip/pip.log
```

I have used factory boy on another machine earlier with Python 3.3 without this issue, so I am not sure why it shows up here and not at the other places.
