### PR TITLE
Implement FACTORY_DJANGO_CUSTOM_MANAGER_METHOD and document usage.

### DIFF
--- a/docs/orms.rst
+++ b/docs/orms.rst
@@ -73,6 +73,23 @@ All factories for a Django :class:`~django.db.models.Model` should use the
             >>> User.objects.all()
             [<User: john>, <User: jack>]
 
+    .. attribute:: FACTORY_DJANGO_CUSTOM_MANAGER_METHOD
+
+        Passing a string with the name of the custom manager method
+        (e.g. `my_manager_method`) will execute
+        :meth:`Model.objects.my_manager_method()` instead of the usual 
+        :meth:`Model.objects.create() <django.db.models.query.QuerySet.create>`.
+
+        .. code-block:: python
+
+            class UserFactory(factory.django.DjangoModelFactory):
+                FACTORY_FOR = 'UserenaSignup'
+                FACTORY_DJANGO_CUSTOM_MANAGER_METHOD = 'create_user'
+
+                username = 'john'
+                email = 'john@gmail.com'
+                password = 'my_password'
+
 
 .. note:: If a :class:`DjangoModelFactory` relates to an :obj:`~django.db.models.Options.abstract`
           model, be sure to declare the :class:`DjangoModelFactory` as abstract:

--- a/factory/django.py
+++ b/factory/django.py
@@ -57,6 +57,7 @@ class DjangoModelFactory(base.Factory):
 
     ABSTRACT_FACTORY = True  # Optional, but explicit.
     FACTORY_DJANGO_GET_OR_CREATE = ()
+    FACTORY_DJANGO_CUSTOM_MANAGER_METHOD = ""
 
     @classmethod
     def _load_target_class(cls, definition):
@@ -113,8 +114,18 @@ class DjangoModelFactory(base.Factory):
         """Create an instance of the model, and save it to the database."""
         manager = cls._get_manager(target_class)
 
+        if (cls.FACTORY_DJANGO_GET_OR_CREATE and
+            cls.FACTORY_DJANGO_CUSTOM_MANAGER_METHOD):
+            raise Exception("Define either FACTORY_DJANGO_GET_OR_CREATE or "
+                            "FACTORY_DJANGO_CUSTOM_MANAGER_METHOD, not both "
+                            "at the same time.")
+
         if cls.FACTORY_DJANGO_GET_OR_CREATE:
             return cls._get_or_create(target_class, *args, **kwargs)
+
+        if cls.FACTORY_DJANGO_CUSTOM_MANAGER_METHOD:
+            return getattr(manager, cls.FACTORY_DJANGO_CUSTOM_MANAGER_METHOD)(
+                *args, **kwargs)
 
         return manager.create(*args, **kwargs)
 


### PR DESCRIPTION
This allows for creating Django-userena user factories without the need of overwriting private Factory methods. Also see [this](https://github.com/rbarrois/factory_boy/issues/115) issue.
