### PR TITLE
Added "prevent_signals" decorator/context manager

### DIFF
--- a/factory/__init__.py
+++ b/factory/__init__.py
@@ -79,5 +79,7 @@ from .helpers import (
     lazy_attribute_sequence,
     container_attribute,
     post_generation,
+
+    prevent_signals,
 )
 

--- a/factory/helpers.py
+++ b/factory/helpers.py
@@ -28,6 +28,7 @@ import logging
 
 from . import base
 from . import declarations
+from . import django
 
 
 @contextlib.contextmanager
@@ -139,3 +140,7 @@ def container_attribute(func):
 
 def post_generation(fun):
     return declarations.PostGeneration(fun)
+
+
+def prevent_signals(*signals):
+    return django.PreventSignals(*signals)

--- a/tests/djapp/models.py
+++ b/tests/djapp/models.py
@@ -74,3 +74,7 @@ if Image is not None:  # PIL is available
 else:
     class WithImage(models.Model):
         pass
+
+
+class WithSignals(models.Model):
+    foo = models.CharField(max_length=20)


### PR DESCRIPTION
This decorator/context manager can help to disable signals of many factories without the need for override the _generate() method.
