### PR TITLE
Also use _safe_repr with args to avoid UnicodeErrors

### DIFF
--- a/factory/utils.py
+++ b/factory/utils.py
@@ -113,7 +113,7 @@ def _safe_repr(obj):
 def log_pprint(args=(), kwargs=None):
     kwargs = kwargs or {}
     return ', '.join(
-        [repr(arg) for arg in args] +
+        [_safe_repr(arg) for arg in args] +
         [
             '%s=%s' % (key, _safe_repr(value))
             for key, value in kwargs.items()


### PR DESCRIPTION
Since the last few commits, I started to get some UnicodeErrors with factory-boy in utils.log_pprint. Using the same _safe_repr function used by `kwargs` with `args` prevent these errors from happening.
