### PR TITLE
Added failing test - Stub generation doesn't respect the 'exclude' spec

### DIFF
--- a/tests/test_using.py
+++ b/tests/test_using.py
@@ -977,6 +977,12 @@ class UsingFactoryTestCase(unittest.TestCase):
         self.assertEqual((), obj.args)
         self.assertEqual({'y': 2, 't': 4}, obj.kwargs)
 
+        stub = TestObjectFactory.stub(x=42, z=5)
+        self.assertFalse(hasattr(stub, 'x'))
+        self.assertFalse(hasattr(stub, 'z'))
+        self.assertTrue(hasattr(stub, 'y'))
+        self.assertTrue(hasattr(stub, 't'))
+
     def test_exclude_and_inline_args(self):
         class TestObject(object):
             def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Hi,

I feel that the `exclude` entries in a factory should be respected by the `stub` methods. I feel that they aren't. I've include a test which should it failing, in my view.

Perhaps this is by design? In which case, please close this, otherwise I'd be happy to try to fix the issue if desirable.

Thanks for factory_boy, I am in awe of how much easier it has made test data creation for my django app.

Cheers,
Michael
