### PR TITLE
Create ImageField files from a callable

### DIFF
--- a/docs/orms.rst
+++ b/docs/orms.rst
@@ -111,6 +111,7 @@ Extra fields
                               and keep its filename
         :param file from_file: Use the contents of the provided file object; use its filename
                                if available, unless ``filename`` is also provided.
+        :param func from_func: Use function that returns a file object
         :param bytes data: Use the provided bytes as file contents
         :param str filename: The filename for the FileField
 

--- a/docs/orms.rst
+++ b/docs/orms.rst
@@ -143,6 +143,7 @@ Extra fields
                               and keep its filename
         :param file from_file: Use the contents of the provided file object; use its filename
                                if available
+        :param func from_func: Use function that returns a file object
         :param str filename: The filename for the ImageField
         :param int width: The width of the generated image (default: ``100``)
         :param int height: The height of the generated image (default: ``100``)

--- a/factory/django.py
+++ b/factory/django.py
@@ -205,9 +205,10 @@ class FileField(declarations.ParameteredAttribute):
     def _make_content(self, params):
         path = ''
 
-        if params.get('from_path') and params.get('from_file'):
+        _content_params = [params.get('from_path'), params.get('from_file'), params.get('from_func')]
+        if len([p for p in _content_params if p]) > 1:
             raise ValueError(
-                "At most one argument from 'from_file' and 'from_path' should "
+                "At most one argument from 'from_file', 'from_path', and 'from_func' should "
                 "be non-empty when calling factory.django.FileField."
             )
 
@@ -219,6 +220,11 @@ class FileField(declarations.ParameteredAttribute):
         elif params.get('from_file'):
             f = params['from_file']
             content = django_files.File(f)
+            path = content.name
+
+        elif params.get('from_func'):
+            func = params['from_func']
+            content = django_files.File(func())
             path = content.name
 
         else:

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -64,6 +64,7 @@ except ImportError:  # pragma: no cover
 
 import factory
 import factory.django
+from factory.compat import BytesIO
 
 from . import testdata
 from . import tools
@@ -693,6 +694,21 @@ class DjangoImageFieldTestCase(unittest.TestCase):
         o = WithImageFactory.build(animage=None)
         self.assertIsNone(o.pk)
         self.assertFalse(o.animage)
+
+    def _img_test_func(self):
+        img = Image.new('RGB', (32,32), 'blue')
+        img_io = BytesIO()
+        img.save(img_io, format='JPEG')
+        img_io.seek(0)
+        return img_io
+
+    def test_with_func(self):
+        o = WithImageFactory.build(animage__from_func=self._img_test_func)
+        self.assertIsNone(o.pk)
+        i = Image.open(o.animage.file)
+        self.assertEqual('JPEG', i.format)
+        self.assertEqual(32, i.width)
+        self.assertEqual(32, i.height)
 
 
 @unittest.skipIf(django is None, "Django not installed.")


### PR DESCRIPTION
Allow dynamic creation of ``factory.django.ImageField`` fields
by passing a function that returns an image file object.