### PR TITLE
Use readthedocs version slug in page titles

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,6 +127,10 @@ html_theme = 'sphinx_rtd_theme'
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
 #html_title = None
+if 'READTHEDOCS_VERSION' in os.environ:
+    # Use the readthedocs version string in preference to our known version.
+    html_title = u"{} {} documentation".format(
+        project, os.environ['READTHEDOCS_VERSION'])
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None


### PR DESCRIPTION
This is primarily a concession to ensure that Google displays more useful version information, see rtfd/readthedocs.org#2147 

This means that for latest/stable, the title will be "Factory Boy latest documentation" or "Factory Boy stable documentation".

For tagged versions *including* this commit, the title will be e.g. "Factory Boy v2.8.1 documentation". For those before this commit, the title will be e.g. "Factory Boy 2.8.1 documentation". It wouldn't be hard to mangle the string to include a *v*, but I thought the added complexity wasn't worth it.

This will not effect builds that do not take place under readthedocs, since they won't set `READTHEDOCS_VERSION`.