### PR TITLE
Test django get or create multiple fields

### DIFF
--- a/factory/base.py
+++ b/factory/base.py
@@ -39,6 +39,7 @@ class FactoryMetaClass(type):
 
         Returns an instance of the associated class.
         """
+        cls.original_kwargs = kwargs
 
         if cls._meta.strategy == enums.BUILD_STRATEGY:
             return cls.build(**kwargs)

--- a/tests/djapp/models.py
+++ b/tests/djapp/models.py
@@ -32,6 +32,11 @@ class MultifieldModel(models.Model):
     text = models.CharField(max_length=20)
 
 
+class MultifieldUniqueModel(models.Model):
+    slug = models.SlugField(max_length=20, unique=True)
+    text = models.CharField(max_length=20, unique=True)
+
+
 class AbstractBase(models.Model):
     foo = models.CharField(max_length=20)
 

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -143,6 +143,15 @@ class WithCustomManagerFactory(factory.django.DjangoModelFactory):
     foo = factory.Sequence(lambda n: "foo%d" % n)
 
 
+class WithMultipleGetOrCreateFieldsFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = models.MultifieldUniqueModel
+        django_get_or_create = ("slug", "text",)
+
+    slug = factory.Sequence(lambda n: "slug%s" % n)
+    text = factory.Sequence(lambda n: "text%s" % n)
+
+
 class ModelTests(django_test.TestCase):
     def test_unset_model(self):
         class UnsetModelFactory(factory.django.DjangoModelFactory):
@@ -217,6 +226,18 @@ class DjangoGetOrCreateTests(django_test.TestCase):
         self.assertEqual(6, len(objs))
         self.assertEqual(2, len(set(objs)))
         self.assertEqual(2, models.MultifieldModel.objects.count())
+
+    def test_multiple_get_or_create_fields_one_defined(self):
+        obj1 = WithMultipleGetOrCreateFieldsFactory()
+        obj2 = WithMultipleGetOrCreateFieldsFactory(slug=obj1.slug)
+        self.assertEqual(obj1, obj2)
+
+    def test_multiple_get_or_create_fields_both_defined(self):
+        obj1 = WithMultipleGetOrCreateFieldsFactory()
+        self.assertRaises(
+            ValueError,
+            lambda: WithMultipleGetOrCreateFieldsFactory(
+                slug=obj1.slug, text="alt"))
 
 
 class DjangoPkForceTestCase(django_test.TestCase):


### PR DESCRIPTION
This adds a failing test for #239 and a fix to make the test pass.

The issue arises when multiple fields with `unique=True` are passed to the `django_get_or_create` option. If one field matches an existing model instance but another does not, Django cannot get or create anything so raises an `IntegrityError`. 

This handles the situation where the field that does not match was provided as a factory_boy default (e.g., via `factory.Sequence`). In this case, we search for the existing model based on the kwargs passed to the factory and return that instance.

In the event that the user passes something impossible to the factory, we raise a verbose `ValueError`.

What I've done is store the original keyword arguments on the class and refer to those using django_get_or_create in the event of the `IntegrityError` mentioned in the issue. Then if the user tries to get_or_create something that is impossible manually, raise a really verbose error.

Let me know if this is helpful and if I could make any improvements? Thanks again for building this!