### PR TITLE
Drop support for Django<1.8 + Adapt to Django deprecation warnings

### DIFF
--- a/tests/djapp/models.py
+++ b/tests/djapp/models.py
@@ -61,7 +61,10 @@ class PointedModel(models.Model):
 
 class PointingModel(models.Model):
     foo = models.CharField(max_length=20)
-    pointed = models.OneToOneField(PointedModel, related_name='pointer', null=True)
+    pointed = models.OneToOneField(
+        PointedModel, related_name='pointer', null=True,
+        on_delete=models.CASCADE
+    )
 
 
 WITHFILE_UPLOAD_TO = 'django'

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35,36}-django{17,18,19,110,111}-alchemy10-mongoengine010
+    py{27,34,35,36}-django{18,19,110,111}-alchemy10-mongoengine010
     examples
     lint
 
@@ -9,12 +9,11 @@ toxworkdir = {env:TOX_WORKDIR:.tox}
 [testenv]
 deps =
     -rrequirements_test.txt
-    django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
-    django{17,18,19,110,111}: Pillow
+    django{18,19,110,111}: Pillow
     alchemy10: SQLAlchemy>=1.0,<1.1
     mongoengine010: mongoengine>=0.10,<0.11
 


### PR DESCRIPTION
- Versions lower than Django 1.8 are no more maintained.
- `on_cascade` will become required starting from django 2.0 on OneToOneFields.
  Adding it to one of the django app examples to avoid deprecation warnings.

Related to bonus ideas in #357.