### PR TITLE
Removing flow control code managing backward compatibility with djang…

### DIFF
--- a/factory/django.py
+++ b/factory/django.py
@@ -58,10 +58,6 @@ def _lazy_load_get_model():
     if django is None:
         def _get_model(app, model):
             raise import_failure
-
-    elif django.VERSION[:2] < (1, 7):
-        from django.db.models.loading import get_model as _get_model
-
     else:
         from django import apps as django_apps
         _get_model = django_apps.apps.get_model
@@ -296,12 +292,11 @@ class mute_signals(object):
                          receivers)
 
             signal.receivers = receivers
-            if django.VERSION[:2] >= (1, 6):
-                with signal.lock:
-                    # Django uses some caching for its signals.
-                    # Since we're bypassing signal.connect and signal.disconnect,
-                    # we have to keep messing with django's internals.
-                    signal.sender_receivers_cache.clear()
+            with signal.lock:
+                # Django uses some caching for its signals.
+                # Since we're bypassing signal.connect and signal.disconnect,
+                # we have to keep messing with django's internals.
+                signal.sender_receivers_cache.clear()
         self.paused = {}
 
     def copy(self):

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -16,15 +16,11 @@ except ImportError:  # pragma: no cover
 if django is not None:
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tests.djapp.settings')
 
-    if django.VERSION >= (1, 7, 0):
-        django.setup()
+    django.setup()
     from django import test as django_test
     from django.conf import settings
     from django.db import models as django_models
-    if django.VERSION <= (1, 8, 0):
-        from django.test.simple import DjangoTestSuiteRunner
-    else:
-        from django.test.runner import DiscoverRunner as DjangoTestSuiteRunner
+    from django.test.runner import DiscoverRunner as DjangoTestSuiteRunner
     from django.test import utils as django_test_utils
     from django.db.models import signals
     from .djapp import models


### PR DESCRIPTION
As we are dropping support for django<1.8, any code checking on `django.version` value was removed if related to <1.8

Related to #363.