### PR TITLE
Remove 3.2 3.3 version mentions  

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ Links
 * Package: https://pypi.python.org/pypi/factory_boy/
 * Mailing-list: `factoryboy@googlegroups.com <mailto:factoryboy@googlegroups.com>`_ | https://groups.google.com/forum/#!forum/factoryboy
 
-factory_boy supports Python 2.7, 3.2 to 3.6, as well as PyPy; it requires only the standard Python library.
+factory_boy supports Python 2.7, 3.4 to 3.6, as well as PyPy; it requires only the standard Python library.
 
 
 Download
@@ -378,4 +378,3 @@ To avoid running ``mongoengine`` tests (e.g no mongo server installed), run:
 .. code-block:: sh
 
     $ make SKIP_MONGOENGINE=1 test
-

--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
Remove stated support for obsolete Python version  #362 