### PR TITLE
[Faker] random state should be set only when calling reseed_random

### DIFF
--- a/factory/faker.py
+++ b/factory/faker.py
@@ -22,7 +22,6 @@ import contextlib
 import faker
 import faker.config
 
-from .random import get_random_state
 from . import declarations
 
 
@@ -77,7 +76,6 @@ class Faker(declarations.BaseDeclaration):
             subfaker = faker.Faker(locale=locale)
             cls._FAKER_REGISTRY[locale] = subfaker
 
-        cls._FAKER_REGISTRY[locale].random.setstate(get_random_state())
         return cls._FAKER_REGISTRY[locale]
 
     @classmethod

--- a/factory/random.py
+++ b/factory/random.py
@@ -23,7 +23,8 @@ def set_random_state(state):
 def reseed_random(seed):
     """Reseed factory.fuzzy's random generator."""
     r = random.Random(seed)
-    set_random_state(r.getstate())
+    random_internal_state = r.getstate()
+    set_random_state(random_internal_state)
 
     for locale in Faker._FAKER_REGISTRY:
-        Faker._FAKER_REGISTRY[locale].random.setstate(r.getstate())
+        Faker._FAKER_REGISTRY[locale].random.setstate(random_internal_state)

--- a/factory/random.py
+++ b/factory/random.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 import random
 
+from factory.faker import Faker
+
 randgen = random.Random()
 
 randgen.state_set = False
@@ -22,3 +24,6 @@ def reseed_random(seed):
     """Reseed factory.fuzzy's random generator."""
     r = random.Random(seed)
     set_random_state(r.getstate())
+
+    for locale in Faker._FAKER_REGISTRY:
+        Faker._FAKER_REGISTRY[locale].random.setstate(r.getstate())

--- a/tests/test_using.py
+++ b/tests/test_using.py
@@ -2211,6 +2211,7 @@ class RepeatableRandomSeedFakerTests(unittest.TestCase):
             one = factory.fuzzy.FuzzyDate(datetime.date(1950, 1, 1), )
             two = factory.Faker('name')
             three = factory.Faker('name', locale='it')
+            four = factory.Faker('name')
 
             class Meta:
                 model = TestObject
@@ -2225,6 +2226,7 @@ class RepeatableRandomSeedFakerTests(unittest.TestCase):
         self.assertEqual(students_1[0].one, students_2[0].one)
         self.assertEqual(students_1[0].two, students_2[0].two)
         self.assertEqual(students_1[0].three, students_2[0].three)
+        self.assertEqual(students_1[0].four, students_2[0].four)
 
 
 class SelfReferentialTests(unittest.TestCase):


### PR DESCRIPTION
For each Faker instanciation, the random state was set from factory.fuzzy.
Now the random state is set only when `factory.random.reseed_random` is called explicitly.
That allows us to have consistancy between fuzzy and faker and also avoid Faker to generate the same set of "randoms" in each instanciation.

This also passes the [DjangoFakerTestCase](https://github.com/FactoryBoy/factory_boy/pull/373/commits/a758df6be6b013552190998ca8f5364a05496311#diff-7c928ff073a9075cc628be362f42a7f7R570) test suggested by @jrobichaud