### PR TITLE
Allow to override the default SQLAlchemy session when creating

### DIFF
--- a/factory/alchemy.py
+++ b/factory/alchemy.py
@@ -67,7 +67,7 @@ class SQLAlchemyModelFactory(base.Factory):
     @classmethod
     def _create(cls, model_class, *args, **kwargs):
         """Create an instance of the model, and save it to the database."""
-        session = cls._meta.sqlalchemy_session
+        session = kwargs.get('sqlalchemy_session', cls._meta.sqlalchemy_session)
         session_persistence = cls._meta.sqlalchemy_session_persistence
         if cls._meta.force_flush:
             session_persistence = SESSION_PERSISTENCE_FLUSH

--- a/factory/alchemy.py
+++ b/factory/alchemy.py
@@ -67,7 +67,7 @@ class SQLAlchemyModelFactory(base.Factory):
     @classmethod
     def _create(cls, model_class, *args, **kwargs):
         """Create an instance of the model, and save it to the database."""
-        session = kwargs.get('sqlalchemy_session', cls._meta.sqlalchemy_session)
+        session = kwargs.pop('sqlalchemy_session', cls._meta.sqlalchemy_session)
         session_persistence = cls._meta.sqlalchemy_session_persistence
         if cls._meta.force_flush:
             session_persistence = SESSION_PERSISTENCE_FLUSH

--- a/tests/test_alchemy.py
+++ b/tests/test_alchemy.py
@@ -208,6 +208,23 @@ class SQLAlchemyNonIntegerPkTestCase(unittest.TestCase):
 
 
 @unittest.skipIf(sqlalchemy is None, "SQLalchemy not installed.")
+class SQLAlchemyOverrideSessionTestCase(unittest.TestCase):
+    def setUp(self):
+        super(SQLAlchemyOverrideSessionTestCase, self).setUp()
+        self.mock_session = mock.NonCallableMagicMock(spec=models.session)
+
+    def test_override_default_session(self):
+        class SomeFactory(StandardFactory):
+            class Meta:
+                sqlalchemy_session = self.mock_session
+                sqlalchemy_session_persistence = 'commit'
+        new_session = mock.NonCallableMagicMock(spec=models.session)
+
+        SomeFactory.create(sqlalchemy_session=new_session)
+
+        new_session.commit.assert_called_once_with()
+
+@unittest.skipIf(sqlalchemy is None, "SQLalchemy not installed.")
 class SQLAlchemyNoSessionTestCase(unittest.TestCase):
 
     def test_create_raises_exception_when_no_session_was_set(self):


### PR DESCRIPTION
This PR allows us to override the session object which is useful in pytest as you usually get a session using a fixture.