### PR TITLE
Convert PostGenerationContext named tuple to dictionary for printing

### DIFF
--- a/factory/declarations.py
+++ b/factory/declarations.py
@@ -562,7 +562,7 @@ class PostGeneration(PostGenerationDeclaration):
             self.function.__name__,
             utils.log_pprint(
                 (instance, step),
-                context,
+                context._asdict(),
             ),
         )
         create = step.builder.strategy == enums.CREATE_STRATEGY


### PR DESCRIPTION
In https://github.com/FactoryBoy/factory_boy/commit/8dadbe20e845ae7e311edf2cefc4ce9e24c25370
PostGenerationContext was changed to a NamedTuple. This causes a crash in utils.log_pprint:110

AttributeError: 'PostGenerationContext' object has no attribute 'items'

This PR fixes the problem, passing both the test suite for factory_boy and my application, but may not be the preferred solution.

