### PR TITLE
Update sequence usage example in the introduction

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -100,9 +100,9 @@ This is achieved with the :class:`~factory.Sequence` declaration:
 .. code-block:: pycon
 
     >>> UserFactory()
-    <User: user1>
+    <User: user0>
     >>> UserFactory()
-    <User: user2>
+    <User: user1>
 
 .. note:: For more complex situations, you may also use the :meth:`~factory.@sequence` decorator (note that ``self`` is not added as first parameter):
 


### PR DESCRIPTION
Since commit 13d310fa14f4e4b9a559f8b7887f2a2492357013, sequences have started on 0 by default instead of 1. Update the usage example in the introduction text to reflect that.