### PR TITLE
fix seeding of random

### DIFF
--- a/factory/builder.py
+++ b/factory/builder.py
@@ -217,7 +217,7 @@ class BuildStep(object):
             sequence=self.sequence,
         )
 
-        for field_name in declarations:
+        for field_name in declarations.sorted():
             self.attributes[field_name] = getattr(self.stub, field_name)
 
     @property

--- a/factory/declarations.py
+++ b/factory/declarations.py
@@ -431,6 +431,7 @@ SKIP = Skip()
 
 class Maybe(BaseDeclaration):
     def __init__(self, decider, yes_declaration=SKIP, no_declaration=SKIP):
+        super(Maybe, self).__init__(*args, **kwargs)
         self.decider = decider
         self.yes = yes_declaration
         self.no = no_declaration
@@ -483,6 +484,7 @@ class Parameter(utils.OrderedBase):
 
 class SimpleParameter(Parameter):
     def __init__(self, value):
+        super(SimpleParameter, self).__init__(*args, **kwargs)
         self.value = value
 
     def as_declarations(self, field_name, declarations):

--- a/factory/declarations.py
+++ b/factory/declarations.py
@@ -431,7 +431,7 @@ SKIP = Skip()
 
 class Maybe(BaseDeclaration):
     def __init__(self, decider, yes_declaration=SKIP, no_declaration=SKIP):
-        super(Maybe, self).__init__(*args, **kwargs)
+        super(Maybe, self).__init__()
         self.decider = decider
         self.yes = yes_declaration
         self.no = no_declaration
@@ -484,7 +484,7 @@ class Parameter(utils.OrderedBase):
 
 class SimpleParameter(Parameter):
     def __init__(self, value):
-        super(SimpleParameter, self).__init__(*args, **kwargs)
+        super(SimpleParameter, self).__init__()
         self.value = value
 
     def as_declarations(self, field_name, declarations):

--- a/factory/faker.py
+++ b/factory/faker.py
@@ -40,7 +40,7 @@ class Faker(declarations.BaseDeclaration):
         >>> foo = factory.Faker('name')
     """
     def __init__(self, provider, locale=None, **kwargs):
-        super(Faker, self).__init__(**kwargs)
+        super(Faker, self).__init__()
         self.provider = provider
         self.provider_kwargs = kwargs
         self.locale = locale

--- a/factory/faker.py
+++ b/factory/faker.py
@@ -40,6 +40,7 @@ class Faker(declarations.BaseDeclaration):
         >>> foo = factory.Faker('name')
     """
     def __init__(self, provider, locale=None, **kwargs):
+        super(Faker, self).__init__(**kwargs)
         self.provider = provider
         self.provider_kwargs = kwargs
         self.locale = locale

--- a/factory/random.py
+++ b/factory/random.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import random
 
+import faker
 from factory.faker import Faker
 
 randgen = random.Random()
@@ -26,5 +27,6 @@ def reseed_random(seed):
     random_internal_state = r.getstate()
     set_random_state(random_internal_state)
 
+    faker.generator.random.seed(seed)
     for locale in Faker._FAKER_REGISTRY:
         Faker._FAKER_REGISTRY[locale].random.setstate(random_internal_state)

--- a/tests/test_using.py
+++ b/tests/test_using.py
@@ -2315,7 +2315,7 @@ class CircularTestCase(unittest.TestCase):
 class RepeatableRandomSeedFakerTests(unittest.TestCase):
     def test_same_seed_is_used_between_fuzzy_and_faker_generators(self):
         class StudentFactory(factory.Factory):
-            one = factory.fuzzy.FuzzyDate(datetime.date(1950, 1, 1), )
+            one = factory.fuzzy.FuzzyDate(datetime.date(1950, 1, 1), datetime.date(1980, 1, 1))
             two = factory.Faker('name')
             three = factory.Faker('name', locale='it')
             four = factory.Faker('name')
@@ -2323,17 +2323,17 @@ class RepeatableRandomSeedFakerTests(unittest.TestCase):
             class Meta:
                 model = TestObject
 
-        seed = "seed1"
+        seed = 1000
         factory.random.reseed_random(seed)
-        students_1 = (StudentFactory(), StudentFactory())
+        students_1 = StudentFactory()
 
         factory.random.reseed_random(seed)
-        students_2 = (StudentFactory(), StudentFactory())
+        students_2 = StudentFactory()
 
-        self.assertEqual(students_1[0].one, students_2[0].one)
-        self.assertEqual(students_1[0].two, students_2[0].two)
-        self.assertEqual(students_1[0].three, students_2[0].three)
-        self.assertEqual(students_1[0].four, students_2[0].four)
+        self.assertEqual(students_1.one, students_2.one)
+        self.assertEqual(students_1.two, students_2.two)
+        self.assertEqual(students_1.three, students_2.three)
+        self.assertEqual(students_1.four, students_2.four)
 
 
 class SelfReferentialTests(unittest.TestCase):


### PR DESCRIPTION
Creating a class with multiple Fakers and LazyAttributes will not give consistent results when seeding for randomness.

* I've modified Faker so the constructor calls `super()` so the `_creation_counter` is incremented.
* I've updated the builder so it creates the attributes in the order it was created.
* I've updated factory/random to set the faker random seed because the faker registry may be empty
* I've updated the test for `RepeatableRandomSeedFakerTest`