### PR TITLE
Add support for passing positional arguments to Faker providers

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -668,7 +668,7 @@ Declarations
 Faker
 """""
 
-.. class:: Faker(provider, locale=None, **kwargs)
+.. class:: Faker(provider, locale=None, args=None, **kwargs)
 
     .. OHAIVIM**
 
@@ -712,6 +712,25 @@ Faker
             >>> user.name
             'Jean Valjean'
 
+
+    .. attribute:: args
+    
+        If positional arguments need to be passed to the provider,
+        use the ``args`` parameter:
+        
+        .. code-block:: python
+        
+            class ComboLockFactory(factory.Factory):
+              class Meta:
+                  model = ComboLock
+                  
+              combination = factory.Faker('pylist', args=(3, False, int))
+              
+        .. code-block:: python
+        
+            >>> lock = ComboLockFactory()
+            >>> lock.combination
+            [42, 7, 13]
 
     .. classmethod:: override_default_locale(cls, locale)
 

--- a/factory/faker.py
+++ b/factory/faker.py
@@ -39,9 +39,10 @@ class Faker(declarations.BaseDeclaration):
     Usage:
         >>> foo = factory.Faker('name')
     """
-    def __init__(self, provider, locale=None, **kwargs):
+    def __init__(self, provider, locale=None, args=None, **kwargs):
         super(Faker, self).__init__()
         self.provider = provider
+        self.provider_args = args or []
         self.provider_kwargs = kwargs
         self.locale = locale
 
@@ -50,7 +51,7 @@ class Faker(declarations.BaseDeclaration):
         kwargs.update(self.provider_kwargs)
         kwargs.update(extra_kwargs)
         subfaker = self._get_faker(self.locale)
-        return subfaker.format(self.provider, **kwargs)
+        return subfaker.format(self.provider, *self.provider_args, **kwargs)
 
     def evaluate(self, instance, step, extra):
         return self.generate(extra or {})

--- a/tests/test_faker.py
+++ b/tests/test_faker.py
@@ -115,3 +115,22 @@ class FakerTests(unittest.TestCase):
         face = FaceFactory()
         self.assertEqual(":)", face.smiley)
         self.assertEqual("(:", face.french_smiley)
+
+    def test_provider_positional_arguments(self):
+
+        class Book(object):
+            def __init__(self, title, bookmarked_pages):
+                self.title = title
+                self.bookmarked_pages = bookmarked_pages
+
+        class BookFactory(factory.Factory):
+            title = factory.Faker('bs')
+            bookmarked_pages = factory.Faker('pylist', args=(6, False, int))
+
+            class Meta:
+                model = Book
+
+        book = BookFactory()
+
+        self.assertEqual(6, len(book.bookmarked_pages))
+        self.assertTrue(all([isinstance(element, int) for element in book.bookmarked_pages]))


### PR DESCRIPTION
This reimplements/replaces #217.

I've added an `args` keyword to the `Faker` class, as recommended in the previous pull request. These then get passed to the underlying provider.