### PR TITLE
Improve FuzzyFloat precision to use freely with postgres

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ ChangeLog
 
 *Bugfix:*
 
+    - Fix :class:`~factory.fuzzy.FuzzyFloat` to return a 15 decimal digits precision float by default
     - :issue:`451`: Restore :class:`~factory.django.FileField` to a
       :class:`~factory.declarations.ParameteredAttribute`, relying on composition to parse the provided parameters.
     - :issue:`389`: Fix random state management with ``faker``.

--- a/factory/fuzzy.py
+++ b/factory/fuzzy.py
@@ -169,18 +169,20 @@ class FuzzyDecimal(BaseFuzzyAttribute):
 class FuzzyFloat(BaseFuzzyAttribute):
     """Random float within a given range."""
 
-    def __init__(self, low, high=None, **kwargs):
+    def __init__(self, low, high=None, precision=15, **kwargs):
         if high is None:
             high = low
             low = 0
 
         self.low = low
         self.high = high
+        self.precision = precision
 
         super(FuzzyFloat, self).__init__(**kwargs)
 
     def fuzz(self):
-        return random.randgen.uniform(self.low, self.high)
+        base = random.randgen.uniform(self.low, self.high)
+        return float(format(base, '.%dg' % self.precision))
 
 
 class FuzzyDate(BaseFuzzyAttribute):

--- a/tests/test_fuzzy.py
+++ b/tests/test_fuzzy.py
@@ -138,8 +138,8 @@ class FuzzyDecimalTestCase(unittest.TestCase):
         fuzz = fuzzy.FuzzyDecimal(1.0, 4.0, precision=5)
         for _i in range(20):
             res = utils.evaluate_declaration(fuzz)
-            self.assertTrue(decimal.Decimal('0.54') <= res <= decimal.Decimal('4.0'),
-                    "value %d is not between 0.54 and 4.0" % res)
+            self.assertTrue(decimal.Decimal('1.0') <= res <= decimal.Decimal('4.0'),
+                    "value %d is not between 1.0 and 4.0" % res)
             self.assertTrue(res.as_tuple().exponent, -5)
 
     def test_biased(self):

--- a/tests/test_fuzzy.py
+++ b/tests/test_fuzzy.py
@@ -186,6 +186,66 @@ class FuzzyDecimalTestCase(unittest.TestCase):
             decimal_context.traps[decimal.FloatOperation] = old_traps
 
 
+class FuzzyFloatTestCase(unittest.TestCase):
+    def test_definition(self):
+        """Tests all ways of defining a FuzzyFloat."""
+        fuzz = fuzzy.FuzzyFloat(2.0, 3.0)
+        for _i in range(20):
+            res = utils.evaluate_declaration(fuzz)
+            self.assertTrue(2.0 <= res <= 3.0, "value %d is not between 2.0 and 3.0" % res)
+
+        fuzz = fuzzy.FuzzyFloat(4.0)
+        for _i in range(20):
+            res = utils.evaluate_declaration(fuzz)
+            self.assertTrue(0.0 <= res <= 4.0, "value %d is not between 0.0 and 4.0" % res)
+
+        fuzz = fuzzy.FuzzyDecimal(1.0, 4.0, precision=5)
+        for _i in range(20):
+            res = utils.evaluate_declaration(fuzz)
+            self.assertTrue(1.0 <= res <= 4.0, "value %d is not between 1.0 and 4.0" % res)
+            self.assertTrue(res.as_tuple().exponent, -5)
+
+    def test_biased(self):
+        fake_uniform = lambda low, high: low + high
+
+        fuzz = fuzzy.FuzzyFloat(2.0, 8.0)
+
+        with mock.patch('factory.random.randgen.uniform', fake_uniform):
+            res = utils.evaluate_declaration(fuzz)
+
+        self.assertEqual(10.0, res)
+
+    def test_biased_high_only(self):
+        fake_uniform = lambda low, high: low + high
+
+        fuzz = fuzzy.FuzzyFloat(8.0)
+
+        with mock.patch('factory.random.randgen.uniform', fake_uniform):
+            res = utils.evaluate_declaration(fuzz)
+
+        self.assertEqual(8.0, res)
+
+    def test_default_precision(self):
+        fake_uniform = lambda low, high: low + high + 0.000000000000011
+
+        fuzz = fuzzy.FuzzyFloat(8.0)
+
+        with mock.patch('factory.random.randgen.uniform', fake_uniform):
+            res = utils.evaluate_declaration(fuzz)
+
+        self.assertEqual(8.00000000000001, res)
+
+    def test_precision(self):
+        fake_uniform = lambda low, high: low + high + 0.001
+
+        fuzz = fuzzy.FuzzyFloat(8.0, precision=4)
+
+        with mock.patch('factory.random.randgen.uniform', fake_uniform):
+            res = utils.evaluate_declaration(fuzz)
+
+        self.assertEqual(8.001, res)
+
+
 class FuzzyDateTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
PostreSQL's default float precision is 15 digits, where python's random
return a 16 digit precision float.

This means that when using a FuzzyFloat field in a factory, the returned
object when calling the factory will have one more digit than the saved
float in the data base.

The PR also contains a smal typo in the FuzzyDecimalTestCase that I spotted