### PR TITLE
Add default argument to extra_kwargs for Faker.generate

### DIFF
--- a/factory/faker.py
+++ b/factory/faker.py
@@ -45,12 +45,12 @@ class Faker(declarations.BaseDeclaration):
         self.provider_kwargs = kwargs
         self.locale = locale
 
-    def generate(self, extra_kwargs={}):
-        kwargs = {}
-        kwargs.update(self.provider_kwargs)
-        kwargs.update(extra_kwargs)
+    def generate(self, **kwargs):
+        _kwargs = {}
+        _kwargs.update(self.provider_kwargs)
+        _kwargs.update(kwargs)
         subfaker = self._get_faker(self.locale)
-        return subfaker.format(self.provider, **kwargs)
+        return subfaker.format(self.provider, **_kwargs)
 
     def evaluate(self, instance, step, extra):
         return self.generate(extra or {})

--- a/factory/faker.py
+++ b/factory/faker.py
@@ -45,7 +45,7 @@ class Faker(declarations.BaseDeclaration):
         self.provider_kwargs = kwargs
         self.locale = locale
 
-    def generate(self, extra_kwargs):
+    def generate(self, extra_kwargs={}):
         kwargs = {}
         kwargs.update(self.provider_kwargs)
         kwargs.update(extra_kwargs)


### PR DESCRIPTION
Currently have to provide extra_kwargs={} for the function to work.
Makes it slightly cleaner if the extra_kwargs argument can be omitted.
Tested in 3.6.5 and 2.7.15

This is my first pull request to a public project so apologies if I've messed up somewhere!