### PR TITLE
Add DictFactory test to demonstrate bug/regression

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -513,6 +513,14 @@ class FactoryCreationTestCase(unittest.TestCase):
 
         self.assertTrue(Test._meta.abstract)
 
+    def test_dict_factory(self):
+        class Test(base.DictFactory):
+            foo = 'bar'
+            spam__ham = 'eggs'
+
+        test = Test()
+        self.assertDictEqual({'foo': 'bar', 'spam__ham': 'eggs'}, test)
+
 
 class PostGenerationParsingTestCase(unittest.TestCase):
 


### PR DESCRIPTION
`__` characters in `DictFactory` used to work ~2.8.1 and less.

`DictFactory` should consider `__` as valid characters and not try to use it as a separator.

```python
Error
Traceback (most recent call last):
  File "/Users/jules/Documents/git/factory_boy/tests/test_base.py", line 517, in test_dict_factory
    class Test(base.DictFactory):
  File "/Users/jules/Documents/git/factory_boy/factory/base.py", line 91, in __new__
    params=attrs_params,
  File "/Users/jules/Documents/git/factory_boy/factory/base.py", line 233, in contribute_to_class
    self.pre_declarations, self.post_declarations = builder.parse_declarations(self.declarations)
  File "/Users/jules/Documents/git/factory_boy/factory/builder.py", line 198, in parse_declarations
    for k, v in extra_maybenonpost.items()
  File "/Users/jules/Documents/git/factory_boy/factory/builder.py", line 92, in update
    sorted(self.declarations),
factory.errors.InvalidDeclarationError: Received deep context for unknown fields: {'spam__ham': 'eggs'} (known=['foo'])
```