### PR TITLE
Lint test files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,7 @@
 [flake8]
-# Ignore "and" at start of line.
-ignore = W503
+ignore =
+    # Ignore "and" at start of line.
+    W503
+    # Ignore "do not assign a lambda expression, use a def".
+    E731
 max-line-length = 120

--- a/CREDITS
+++ b/CREDITS
@@ -36,6 +36,7 @@ The project has received contributions from (in alphabetical order):
 * Demur Nodia <demur.nodia@gmail.com> (https://github.com/demonno)
 * Eduard Iskandarov <edikexp@gmail.com>
 * Flavio Curella <flavio.curella@gmail.com>
+* François Freitag <mail@franek.fr>
 * George Hickman <george@ghickman.co.uk>
 * Hervé Cauwelier <herve.cauwelier@polyconseil.fr>
 * Ilya Baryshev <baryshev@gmail.com>

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ example-test:
 # Note: we run the linter in two runs, because our __init__.py files has specific warnings we want to exclude
 # DOC: Perform code quality tasks
 lint:
-	$(FLAKE8) --config .flake8 --exclude $(PACKAGE)/__init__.py $(PACKAGE) $(SETUP_PY)
+	$(FLAKE8) --config .flake8 --exclude $(PACKAGE)/__init__.py $(PACKAGE) $(SETUP_PY) $(TESTS_DIR)
 	$(FLAKE8) --config .flake8 --ignore F401 $(PACKAGE)/__init__.py
 	check-manifest
 

--- a/tests/alchemyapp/models.py
+++ b/tests/alchemyapp/models.py
@@ -26,4 +26,5 @@ class NonIntegerPk(Base):
 
     id = Column(Unicode(20), primary_key=True)
 
+
 Base.metadata.create_all(engine)

--- a/tests/alter_time.py
+++ b/tests/alter_time.py
@@ -12,6 +12,7 @@ from .compat import mock
 
 real_datetime_class = datetime.datetime
 
+
 def mock_datetime_now(target, datetime_module):
     """Override ``datetime.datetime.now()`` with a custom target value.
 
@@ -48,7 +49,9 @@ def mock_datetime_now(target, datetime_module):
 
     return mock.patch.object(datetime_module, 'datetime', MockedDatetime)
 
+
 real_date_class = datetime.date
+
 
 def mock_date_today(target, datetime_module):
     """Override ``datetime.date.today()`` with a custom target value.
@@ -97,7 +100,6 @@ def main():  # pragma: no cover
         print("- today                     ->", datetime.date.today())
         print("- isinstance(now, date)     ->", isinstance(datetime.date.today(), datetime.date))
         print("- isinstance(target, date)  ->", isinstance(target_date, datetime.date))
-
 
     print("Outside mock")
     print("- now                       ->", datetime.datetime.now())

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -7,18 +7,17 @@ import sys
 
 is_python2 = (sys.version_info[0] == 2)
 
-if sys.version_info[0:2] < (2, 7):  # pragma: no cover
+if sys.version_info[0:2] < (2, 7):
     import unittest2 as unittest
-else:  # pragma: no cover
-    import unittest
+else:
+    import unittest  # noqa: F401
 
-if sys.version_info[0] == 2:  # pragma: no cover
+if is_python2:
     import StringIO as io
-else:  # pragma: no cover
-    import io
+else:
+    import io  # noqa: F401
 
-if sys.version_info[0:2] < (3, 3):  # pragma: no cover
+if sys.version_info[0:2] < (3, 3):
     import mock
-else:  # pragma: no cover
-    from unittest import mock
-
+else:
+    from unittest import mock  # noqa: F401

--- a/tests/cyclic/bar.py
+++ b/tests/cyclic/bar.py
@@ -5,6 +5,7 @@
 
 import factory
 
+
 class Bar(object):
     def __init__(self, foo, y):
         self.foo = foo
@@ -17,4 +18,3 @@ class BarFactory(factory.Factory):
 
     y = 13
     foo = factory.SubFactory('cyclic.foo.FooFactory')
-

--- a/tests/cyclic/foo.py
+++ b/tests/cyclic/foo.py
@@ -7,6 +7,7 @@ import factory
 
 from . import bar as bar_mod
 
+
 class Foo(object):
     def __init__(self, bar, x):
         self.bar = bar

--- a/tests/cyclic/self_ref.py
+++ b/tests/cyclic/self_ref.py
@@ -5,6 +5,7 @@
 
 import factory
 
+
 class TreeElement(object):
     def __init__(self, name, parent):
         self.parent = parent

--- a/tests/djapp/models.py
+++ b/tests/djapp/models.py
@@ -77,6 +77,7 @@ class WithDefaultValue(models.Model):
 WITHFILE_UPLOAD_TO = 'django'
 WITHFILE_UPLOAD_DIR = os.path.join(settings.MEDIA_ROOT, WITHFILE_UPLOAD_TO)
 
+
 class WithFile(models.Model):
     afile = models.FileField(upload_to=WITHFILE_UPLOAD_TO)
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 # Copyright: See the LICENSE file.
 
-import warnings
-
 from factory import base
 from factory import declarations
 from factory import enums
 from factory import errors
 
 from .compat import unittest
+
 
 class TestObject(object):
     def __init__(self, one=None, two=None, three=None, four=None):
@@ -245,7 +244,7 @@ class FactoryTestCase(unittest.TestCase):
             class Meta:
                 model = TestObject
 
-            one = declarations.LazyAttribute(lambda a: a.does_not_exist )
+            one = declarations.LazyAttribute(lambda a: a.does_not_exist)
 
         self.assertRaises(AttributeError, TestObjectFactory)
 
@@ -347,7 +346,6 @@ class FactorySequenceTestCase(unittest.TestCase):
 
         o4 = self.TestObjectFactory()
         self.assertEqual(1, o4.one)
-
 
 
 class FactoryDefaultStrategyTestCase(unittest.TestCase):
@@ -535,7 +533,6 @@ class PostGenerationParsingTestCase(unittest.TestCase):
 
         self.assertIn('foo', TestObjectFactory._meta.post_declarations.as_dict())
         self.assertIn('foo__bar', TestObjectFactory._meta.post_declarations.as_dict())
-
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/tests/test_declarations.py
+++ b/tests/test_declarations.py
@@ -2,7 +2,6 @@
 # Copyright: See the LICENSE file.
 
 import datetime
-import itertools
 
 from factory import base
 from factory import declarations
@@ -125,6 +124,7 @@ class IteratorTestCase(unittest.TestCase):
 class PostGenerationDeclarationTestCase(unittest.TestCase):
     def test_post_generation(self):
         call_params = []
+
         def foo(*args, **kwargs):
             call_params.append(args)
             call_params.append(kwargs)
@@ -143,6 +143,7 @@ class PostGenerationDeclarationTestCase(unittest.TestCase):
 
     def test_decorator_simple(self):
         call_params = []
+
         @helpers.post_generation
         def foo(*args, **kwargs):
             call_params.append(args)
@@ -215,7 +216,7 @@ class PostGenerationMethodCallTestCase(unittest.TestCase):
 
     def test_call_with_method_args(self):
         obj = self.build(
-            declarations.PostGenerationMethodCall( 'method', 'data'),
+            declarations.PostGenerationMethodCall('method', 'data'),
         )
         obj.method.assert_called_once_with('data')
 
@@ -255,7 +256,7 @@ class PostGenerationMethodCallTestCase(unittest.TestCase):
 
     def test_multi_call_with_multi_method_args(self):
         with self.assertRaises(errors.InvalidDeclarationError):
-            obj = self.build(
+            self.build(
                 declarations.PostGenerationMethodCall('method', 'arg1', 'arg2'),
             )
 

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -4,24 +4,19 @@
 """Tests for factory_boy/Django interactions."""
 
 import os
-from .compat import is_python2, unittest, mock
-
 
 import django
 
 # Setup Django as soon as possible
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tests.djapp.settings')
-
 django.setup()
-from django import test as django_test
-from django.conf import settings
-from django.db import models as django_models
-from django.test.runner import DiscoverRunner as DjangoTestSuiteRunner
-from django.test import utils as django_test_utils
-from django.db.models import signals
-from .djapp import models
 
-
+from django import test as django_test  # noqa: E402
+from django.conf import settings  # noqa: E402
+from django.test.runner import DiscoverRunner as DjangoTestSuiteRunner  # noqa: E402
+from django.test import utils as django_test_utils  # noqa: E402
+from django.db.models import signals  # noqa: E402
+from .djapp import models  # noqa: E402
 try:
     from PIL import Image
 except ImportError:  # pragma: no cover
@@ -32,12 +27,12 @@ except ImportError:  # pragma: no cover
         # OK, not installed
         Image = None
 
+import factory  # noqa: E402
+import factory.django  # noqa: E402
+from factory.compat import BytesIO  # noqa: E402
 
-import factory
-import factory.django
-from factory.compat import BytesIO
-
-from . import testdata
+from . import testdata  # noqa: E402
+from .compat import unittest, mock  # noqa: E402
 
 
 test_state = {}
@@ -201,7 +196,7 @@ class DjangoGetOrCreateTests(django_test.TestCase):
     def test_simple_call(self):
         obj1 = MultifieldModelFactory(slug='slug1')
         obj2 = MultifieldModelFactory(slug='slug1')
-        obj3 = MultifieldModelFactory(slug='alt')
+        MultifieldModelFactory(slug='alt')
 
         self.assertEqual(obj1, obj2)
         self.assertEqual(2, models.MultifieldModel.objects.count())
@@ -211,7 +206,8 @@ class DjangoGetOrCreateTests(django_test.TestCase):
             MultifieldModelFactory()
 
     def test_multicall(self):
-        objs = MultifieldModelFactory.create_batch(6,
+        objs = MultifieldModelFactory.create_batch(
+            6,
             slug=factory.Iterator(['main', 'alt']),
         )
         self.assertEqual(6, len(objs))
@@ -340,12 +336,12 @@ class DjangoNonIntegerPkTestCase(django_test.TestCase):
 
 
 class DjangoAbstractBaseSequenceTestCase(django_test.TestCase):
-    def test_auto_sequence(self):
+    def test_auto_sequence_son(self):
         """The sequence of the concrete son of an abstract model should be autonomous."""
         obj = ConcreteSonFactory()
         self.assertEqual(1, obj.pk)
 
-    def test_auto_sequence(self):
+    def test_auto_sequence_grandson(self):
         """The sequence of the concrete grandson of an abstract model should be autonomous."""
         obj = ConcreteGrandSonFactory()
         self.assertEqual(1, obj.pk)
@@ -372,6 +368,7 @@ class DjangoRelatedFieldTestCase(django_test.TestCase):
     @classmethod
     def setUpClass(cls):
         super(DjangoRelatedFieldTestCase, cls).setUpClass()
+
         class PointedFactory(factory.django.DjangoModelFactory):
             class Meta:
                 model = models.PointedModel
@@ -518,7 +515,9 @@ class DjangoFileFieldTestCase(django_test.TestCase):
         self.assertEqual('django/example.data', o.afile.name)
 
     def test_error_both_file_and_path(self):
-        self.assertRaises(ValueError, WithFileFactory.build,
+        self.assertRaises(
+            ValueError,
+            WithFileFactory.build,
             afile__from_file='fakefile',
             afile__from_path=testdata.TESTFILE_PATH,
         )
@@ -718,7 +717,9 @@ class DjangoImageFieldTestCase(django_test.TestCase):
         self.assertEqual('django/example.jpeg', o.animage.name)
 
     def test_error_both_file_and_path(self):
-        self.assertRaises(ValueError, WithImageFactory.build,
+        self.assertRaises(
+            ValueError,
+            WithImageFactory.build,
             animage__from_file='fakefile',
             animage__from_path=testdata.TESTIMAGE_PATH,
         )
@@ -754,7 +755,7 @@ class DjangoImageFieldTestCase(django_test.TestCase):
         self.assertFalse(o.animage)
 
     def _img_test_func(self):
-        img = Image.new('RGB', (32,32), 'blue')
+        img = Image.new('RGB', (32, 32), 'blue')
         img_io = BytesIO()
         img.save(img_io, format='JPEG')
         img_io.seek(0)
@@ -893,7 +894,7 @@ class DjangoCustomManagerTestCase(django_test.TestCase):
 
     def test_extra_args(self):
         # Our CustomManager will remove the 'arg=' argument.
-        model = WithCustomManagerFactory(arg='foo')
+        WithCustomManagerFactory(arg='foo')
 
     def test_with_manager_on_abstract(self):
         class ObjFactory(factory.django.DjangoModelFactory):

--- a/tests/test_docs_internals.py
+++ b/tests/test_docs_internals.py
@@ -29,9 +29,9 @@ from factory.compat import UTC
 from .compat import unittest
 
 
-
 class User(object):
-    def __init__(self,
+    def __init__(
+        self,
         username,
         full_name,
         is_active=True,
@@ -103,7 +103,6 @@ class UserFactory(factory.Factory):
         'enabled',
         None,
         factory.fuzzy.FuzzyDateTime(
-#            factory.SelfAttribute('creation_date'),
             datetime.datetime.now().replace(tzinfo=UTC) - datetime.timedelta(days=10),
             datetime.datetime.now().replace(tzinfo=UTC) - datetime.timedelta(days=1),
         ),

--- a/tests/test_fuzzy.py
+++ b/tests/test_fuzzy.py
@@ -126,20 +126,26 @@ class FuzzyDecimalTestCase(unittest.TestCase):
         fuzz = fuzzy.FuzzyDecimal(2.0, 3.0)
         for _i in range(20):
             res = utils.evaluate_declaration(fuzz)
-            self.assertTrue(decimal.Decimal('2.0') <= res <= decimal.Decimal('3.0'),
-                    "value %d is not between 2.0 and 3.0" % res)
+            self.assertTrue(
+                decimal.Decimal('2.0') <= res <= decimal.Decimal('3.0'),
+                "value %d is not between 2.0 and 3.0" % res,
+            )
 
         fuzz = fuzzy.FuzzyDecimal(4.0)
         for _i in range(20):
             res = utils.evaluate_declaration(fuzz)
-            self.assertTrue(decimal.Decimal('0.0') <= res <= decimal.Decimal('4.0'),
-                    "value %d is not between 0.0 and 4.0" % res)
+            self.assertTrue(
+                decimal.Decimal('0.0') <= res <= decimal.Decimal('4.0'),
+                "value %d is not between 0.0 and 4.0" % res,
+            )
 
         fuzz = fuzzy.FuzzyDecimal(1.0, 4.0, precision=5)
         for _i in range(20):
             res = utils.evaluate_declaration(fuzz)
-            self.assertTrue(decimal.Decimal('1.0') <= res <= decimal.Decimal('4.0'),
-                    "value %d is not between 1.0 and 4.0" % res)
+            self.assertTrue(
+                decimal.Decimal('1.0') <= res <= decimal.Decimal('4.0'),
+                "value %d is not between 1.0 and 4.0" % res,
+            )
             self.assertTrue(res.as_tuple().exponent, -5)
 
     def test_biased(self):
@@ -274,13 +280,20 @@ class FuzzyDateTestCase(unittest.TestCase):
             self.assertLessEqual(res, self.jan3)
 
     def test_invalid_definition(self):
-        self.assertRaises(ValueError, fuzzy.FuzzyDate,
-            self.jan31, self.jan1)
+        self.assertRaises(
+            ValueError,
+            fuzzy.FuzzyDate,
+            self.jan31,
+            self.jan1,
+        )
 
     def test_invalid_partial_definition(self):
         with utils.mocked_date_today(self.jan1, fuzzy):
-            self.assertRaises(ValueError, fuzzy.FuzzyDate,
-                self.jan31)
+            self.assertRaises(
+                ValueError,
+                fuzzy.FuzzyDate,
+                self.jan31,
+            )
 
     def test_biased(self):
         """Tests a FuzzyDate with a biased random.randint."""
@@ -334,13 +347,21 @@ class FuzzyNaiveDateTimeTestCase(unittest.TestCase):
 
     def test_aware_start(self):
         """Tests that a timezone-aware start datetime is rejected."""
-        self.assertRaises(ValueError, fuzzy.FuzzyNaiveDateTime,
-            self.jan1.replace(tzinfo=compat.UTC), self.jan31)
+        self.assertRaises(
+            ValueError,
+            fuzzy.FuzzyNaiveDateTime,
+            self.jan1.replace(tzinfo=compat.UTC),
+            self.jan31,
+        )
 
     def test_aware_end(self):
         """Tests that a timezone-aware end datetime is rejected."""
-        self.assertRaises(ValueError, fuzzy.FuzzyNaiveDateTime,
-            self.jan1, self.jan31.replace(tzinfo=compat.UTC))
+        self.assertRaises(
+            ValueError,
+            fuzzy.FuzzyNaiveDateTime,
+            self.jan1,
+            self.jan31.replace(tzinfo=compat.UTC),
+        )
 
     def test_force_year(self):
         fuzz = fuzzy.FuzzyNaiveDateTime(self.jan1, self.jan31, force_year=4)
@@ -392,13 +413,20 @@ class FuzzyNaiveDateTimeTestCase(unittest.TestCase):
             self.assertEqual(4, res.microsecond)
 
     def test_invalid_definition(self):
-        self.assertRaises(ValueError, fuzzy.FuzzyNaiveDateTime,
-            self.jan31, self.jan1)
+        self.assertRaises(
+            ValueError,
+            fuzzy.FuzzyNaiveDateTime,
+            self.jan31,
+            self.jan1,
+        )
 
     def test_invalid_partial_definition(self):
         with utils.mocked_datetime_now(self.jan1, fuzzy):
-            self.assertRaises(ValueError, fuzzy.FuzzyNaiveDateTime,
-                self.jan31)
+            self.assertRaises(
+                ValueError,
+                fuzzy.FuzzyNaiveDateTime,
+                self.jan31,
+            )
 
     def test_biased(self):
         """Tests a FuzzyDate with a biased random.randint."""
@@ -451,23 +479,38 @@ class FuzzyDateTimeTestCase(unittest.TestCase):
             self.assertLessEqual(res, self.jan3)
 
     def test_invalid_definition(self):
-        self.assertRaises(ValueError, fuzzy.FuzzyDateTime,
-            self.jan31, self.jan1)
+        self.assertRaises(
+            ValueError,
+            fuzzy.FuzzyDateTime,
+            self.jan31,
+            self.jan1,
+        )
 
     def test_invalid_partial_definition(self):
         with utils.mocked_datetime_now(self.jan1, fuzzy):
-            self.assertRaises(ValueError, fuzzy.FuzzyDateTime,
-                self.jan31)
+            self.assertRaises(
+                ValueError,
+                fuzzy.FuzzyDateTime,
+                self.jan31,
+            )
 
     def test_naive_start(self):
         """Tests that a timezone-naive start datetime is rejected."""
-        self.assertRaises(ValueError, fuzzy.FuzzyDateTime,
-            self.jan1.replace(tzinfo=None), self.jan31)
+        self.assertRaises(
+            ValueError,
+            fuzzy.FuzzyDateTime,
+            self.jan1.replace(tzinfo=None),
+            self.jan31,
+        )
 
     def test_naive_end(self):
         """Tests that a timezone-naive end datetime is rejected."""
-        self.assertRaises(ValueError, fuzzy.FuzzyDateTime,
-            self.jan1, self.jan31.replace(tzinfo=None))
+        self.assertRaises(
+            ValueError,
+            fuzzy.FuzzyDateTime,
+            self.jan1,
+            self.jan31.replace(tzinfo=None),
+        )
 
     def test_force_year(self):
         fuzz = fuzzy.FuzzyDateTime(self.jan1, self.jan31, force_year=4)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -15,18 +15,18 @@ class DebugTest(unittest.TestCase):
         stream1 = io.StringIO()
         stream2 = io.StringIO()
 
-        l = logging.getLogger('factory.test')
+        logger = logging.getLogger('factory.test')
         h = logging.StreamHandler(stream1)
         h.setLevel(logging.INFO)
-        l.addHandler(h)
+        logger.addHandler(h)
 
         # Non-debug: no text gets out
-        l.debug("Test")
+        logger.debug("Test")
         self.assertEqual('', stream1.getvalue())
 
         with helpers.debug(stream=stream2):
             # Debug: text goes to new stream only
-            l.debug("Test2")
+            logger.debug("Test2")
 
         self.assertEqual('', stream1.getvalue())
         self.assertEqual("Test2\n", stream2.getvalue())
@@ -54,4 +54,3 @@ class DebugTest(unittest.TestCase):
 
         self.assertEqual("", stream1.getvalue())
         self.assertEqual("Test2\n", stream2.getvalue())
-

--- a/tests/test_mongoengine.py
+++ b/tests/test_mongoengine.py
@@ -12,18 +12,22 @@ import mongoengine
 
 from factory.mongoengine import MongoEngineFactory
 
+
 class Address(mongoengine.EmbeddedDocument):
     street = mongoengine.StringField()
+
 
 class Person(mongoengine.Document):
     name = mongoengine.StringField()
     address = mongoengine.EmbeddedDocumentField(Address)
+
 
 class AddressFactory(MongoEngineFactory):
     class Meta:
         model = Address
 
     street = factory.Sequence(lambda n: 'street%d' % n)
+
 
 class PersonFactory(MongoEngineFactory):
     class Meta:

--- a/tests/test_using.py
+++ b/tests/test_using.py
@@ -6,10 +6,8 @@
 
 import collections
 import datetime
-import functools
 import os
 import sys
-import warnings
 
 import factory
 from factory import errors
@@ -123,8 +121,12 @@ class SimpleBuildTestCase(unittest.TestCase):
         self.assertEqual(obj.four, None)
 
     def test_build_batch(self):
-        objs = factory.build_batch(TestObject, 4, two=2,
-            three=factory.LazyAttribute(lambda o: o.two + 1))
+        objs = factory.build_batch(
+            TestObject,
+            4,
+            two=2,
+            three=factory.LazyAttribute(lambda o: o.two + 1),
+        )
 
         self.assertEqual(4, len(objs))
         self.assertEqual(4, len(set(objs)))
@@ -156,8 +158,12 @@ class SimpleBuildTestCase(unittest.TestCase):
             self.assertEqual(obj.foo, 'bar')
 
     def test_create_batch_custom_base(self):
-        objs = factory.create_batch(FakeModel, 4, foo='bar',
-                FACTORY_CLASS=factory.django.DjangoModelFactory)
+        objs = factory.create_batch(
+            FakeModel,
+            4,
+            foo='bar',
+            FACTORY_CLASS=factory.django.DjangoModelFactory,
+        )
 
         self.assertEqual(4, len(objs))
         self.assertEqual(4, len(set(objs)))
@@ -192,8 +198,12 @@ class SimpleBuildTestCase(unittest.TestCase):
         self.assertEqual(obj.foo, 'bar')
 
     def test_generate_create_custom_base(self):
-        obj = factory.generate(FakeModel, factory.CREATE_STRATEGY, foo='bar',
-                FACTORY_CLASS=factory.django.DjangoModelFactory)
+        obj = factory.generate(
+            FakeModel,
+            factory.CREATE_STRATEGY,
+            foo='bar',
+            FACTORY_CLASS=factory.django.DjangoModelFactory,
+        )
         self.assertEqual(obj.id, 2)
         self.assertEqual(obj.foo, 'bar')
 
@@ -223,8 +233,13 @@ class SimpleBuildTestCase(unittest.TestCase):
             self.assertEqual(obj.foo, 'bar')
 
     def test_generate_batch_create_custom_base(self):
-        objs = factory.generate_batch(FakeModel, factory.CREATE_STRATEGY, 20, foo='bar',
-                FACTORY_CLASS=factory.django.DjangoModelFactory)
+        objs = factory.generate_batch(
+            FakeModel,
+            factory.CREATE_STRATEGY,
+            20,
+            foo='bar',
+            FACTORY_CLASS=factory.django.DjangoModelFactory,
+        )
 
         self.assertEqual(20, len(objs))
         self.assertEqual(20, len(set(objs)))
@@ -279,8 +294,13 @@ class SimpleBuildTestCase(unittest.TestCase):
             self.assertEqual(obj.foo, 'bar')
 
     def test_simple_generate_batch_create_custom_base(self):
-        objs = factory.simple_generate_batch(FakeModel, True, 20, foo='bar',
-                FACTORY_CLASS=factory.django.DjangoModelFactory)
+        objs = factory.simple_generate_batch(
+            FakeModel,
+            True,
+            20,
+            foo='bar',
+            FACTORY_CLASS=factory.django.DjangoModelFactory,
+        )
 
         self.assertEqual(20, len(objs))
         self.assertEqual(20, len(set(objs)))
@@ -463,7 +483,7 @@ class UsingFactoryTestCase(unittest.TestCase):
             class Meta:
                 model = TestObject
 
-            one = factory.LazyAttribute(lambda a: 'abc' )
+            one = factory.LazyAttribute(lambda a: 'abc')
             two = factory.LazyAttribute(lambda a: a.one + ' xyz')
 
         test_object = TestObjectFactory.build()
@@ -557,6 +577,7 @@ class UsingFactoryTestCase(unittest.TestCase):
             @factory.lazy_attribute_sequence
             def one(a, n):
                 return 'one%d' % n
+
             @factory.lazy_attribute_sequence
             def two(a, n):
                 return a.one + ' two%d' % n
@@ -759,8 +780,10 @@ class UsingFactoryTestCase(unittest.TestCase):
             two = factory.LazyAttribute(lambda a: a.one + ' two')
             three = factory.Sequence(lambda n: int(n))
 
-        objs = TestObjectFactory.stub_batch(20,
-            one=factory.Sequence(lambda n: str(n)))
+        objs = TestObjectFactory.stub_batch(
+            20,
+            one=factory.Sequence(lambda n: str(n)),
+        )
 
         self.assertEqual(20, len(objs))
         self.assertEqual(20, len(set(objs)))
@@ -902,7 +925,6 @@ class UsingFactoryTestCase(unittest.TestCase):
         to2b = TestObjectFactory2()
         self.assertEqual(1, to2b.one)
 
-
     def test_inheritance_with_inherited_class(self):
         class TestObjectFactory(factory.Factory):
             class Meta:
@@ -1027,7 +1049,6 @@ class UsingFactoryTestCase(unittest.TestCase):
         self.assertEqual({'t': 4}, obj.kwargs)
 
 
-
 class NonKwargParametersTestCase(unittest.TestCase):
     def test_build(self):
         class TestObject(object):
@@ -1148,7 +1169,11 @@ class MaybeTestCase(unittest.TestCase):
             # biggest = 'b' if .b > .a else 'a'
             biggest = factory.Maybe(factory.LazyAttribute(lambda o: o.a < o.b), 'b', 'a')
             # max_value = .b if .b > .a else .a = max(.a, .b)
-            max_value = factory.Maybe(factory.LazyAttribute(lambda o: o.a < o.b), factory.SelfAttribute('b'), factory.SelfAttribute('a'))
+            max_value = factory.Maybe(
+                factory.LazyAttribute(lambda o: o.a < o.b),
+                factory.SelfAttribute('b'),
+                factory.SelfAttribute('a'),
+            )
 
         obj_ordered = DummyFactory.build(a=1, b=2)
         obj_equal = DummyFactory.build(a=3, b=3)
@@ -1176,7 +1201,6 @@ class MaybeTestCase(unittest.TestCase):
         @factory.post_generation
         def decrement(obj, *args, **kwargs):
             obj.value -= 1
-
 
         class DummyFactory(factory.Factory):
             class Meta:
@@ -1211,24 +1235,34 @@ class TraitTestCase(unittest.TestCase):
                 odd = factory.Trait(one=True, three=True, five=True)
 
         obj1 = TestObjectFactory()
-        self.assertEqual(obj1.as_dict(),
-            dict(one=None, two=None, three=None, four=None, five=None))
+        self.assertEqual(
+            obj1.as_dict(),
+            dict(one=None, two=None, three=None, four=None, five=None),
+        )
 
         obj2 = TestObjectFactory(even=True)
-        self.assertEqual(obj2.as_dict(),
-            dict(one=None, two=True, three=None, four=True, five=None))
+        self.assertEqual(
+            obj2.as_dict(),
+            dict(one=None, two=True, three=None, four=True, five=None),
+        )
 
         obj3 = TestObjectFactory(odd=True)
-        self.assertEqual(obj3.as_dict(),
-            dict(one=True, two=None, three=True, four=None, five=True))
+        self.assertEqual(
+            obj3.as_dict(),
+            dict(one=True, two=None, three=True, four=None, five=True),
+        )
 
         obj4 = TestObjectFactory(even=True, odd=True)
-        self.assertEqual(obj4.as_dict(),
-            dict(one=True, two=True, three=True, four=True, five=True))
+        self.assertEqual(
+            obj4.as_dict(),
+            dict(one=True, two=True, three=True, four=True, five=True),
+        )
 
         obj5 = TestObjectFactory(odd=True, two=True)
-        self.assertEqual(obj5.as_dict(),
-            dict(one=True, two=True, three=True, four=None, five=True))
+        self.assertEqual(
+            obj5.as_dict(),
+            dict(one=True, two=True, three=True, four=None, five=True),
+        )
 
     def test_post_generation_traits(self):
         @factory.post_generation
@@ -1240,6 +1274,7 @@ class TraitTestCase(unittest.TestCase):
                 model = Dummy
 
             value = 3
+
             class Params:
                 exponentiate = factory.Trait(apply_exponent=compute)
 
@@ -1267,13 +1302,17 @@ class TraitTestCase(unittest.TestCase):
 
         # Simple call
         obj1 = EvenObjectFactory()
-        self.assertEqual(obj1.as_dict(),
-            dict(one=None, two=True, three=None, four=True, five=None))
+        self.assertEqual(
+            obj1.as_dict(),
+            dict(one=None, two=True, three=None, four=True, five=None),
+        )
 
         # Force-disable it
         obj2 = EvenObjectFactory(even=False)
-        self.assertEqual(obj2.as_dict(),
-            dict(one=None, two=None, three=None, four=None, five=None))
+        self.assertEqual(
+            obj2.as_dict(),
+            dict(one=None, two=None, three=None, four=None, five=None),
+        )
 
     def test_traits_override(self):
         """Override a trait in a subclass."""
@@ -1291,8 +1330,10 @@ class TraitTestCase(unittest.TestCase):
                 even = factory.Trait(two=True, four=True, one=True)
 
         obj = WeirdMathFactory(even=True)
-        self.assertEqual(obj.as_dict(),
-            dict(one=True, two=True, three=None, four=True, five=None))
+        self.assertEqual(
+            obj.as_dict(),
+            dict(one=True, two=True, three=None, four=True, five=None),
+        )
 
     def test_traits_chaining(self):
         """Use a trait to enable other traits."""
@@ -1308,26 +1349,36 @@ class TraitTestCase(unittest.TestCase):
 
         # Setting "full" should enable all fields.
         obj = TestObjectFactory(full=True)
-        self.assertEqual(obj.as_dict(),
-            dict(one=True, two=True, three=True, four=True, five=True))
+        self.assertEqual(
+            obj.as_dict(),
+            dict(one=True, two=True, three=True, four=True, five=True),
+        )
 
         # Does it break usual patterns?
         obj1 = TestObjectFactory()
-        self.assertEqual(obj1.as_dict(),
-            dict(one=None, two=None, three=None, four=None, five=None))
+        self.assertEqual(
+            obj1.as_dict(),
+            dict(one=None, two=None, three=None, four=None, five=None),
+        )
 
         obj2 = TestObjectFactory(even=True)
-        self.assertEqual(obj2.as_dict(),
-            dict(one=None, two=True, three=None, four=True, five=None))
+        self.assertEqual(
+            obj2.as_dict(),
+            dict(one=None, two=True, three=None, four=True, five=None),
+        )
 
         obj3 = TestObjectFactory(odd=True)
-        self.assertEqual(obj3.as_dict(),
-            dict(one=True, two=None, three=True, four=None, five=True))
+        self.assertEqual(
+            obj3.as_dict(),
+            dict(one=True, two=None, three=True, four=None, five=True),
+        )
 
         # Setting override should override two and set it to False
         obj = TestObjectFactory(override=True)
-        self.assertEqual(obj.as_dict(),
-            dict(one=None, two=False, three=None, four=True, five=None))
+        self.assertEqual(
+            obj.as_dict(),
+            dict(one=None, two=False, three=None, four=True, five=None),
+        )
 
     def test_prevent_cyclic_traits(self):
 
@@ -1423,7 +1474,8 @@ class SubFactoryTestCase(unittest.TestCase):
         class TestModel2Factory(FakeModelFactory):
             class Meta:
                 model = TestModel2
-            two = factory.SubFactory(TestModelFactory,
+            two = factory.SubFactory(
+                TestModelFactory,
                 one=factory.Sequence(lambda n: 'x%dx' % n),
                 two=factory.LazyAttribute(lambda o: '%s%s' % (o.one, o.one)),
             )
@@ -1445,7 +1497,8 @@ class SubFactoryTestCase(unittest.TestCase):
             class Meta:
                 model = TestModel2
             one = 'parent'
-            child = factory.SubFactory(TestModelFactory,
+            child = factory.SubFactory(
+                TestModelFactory,
                 one=factory.LazyAttribute(lambda o: '%s child' % o.factory_parent.one),
             )
 
@@ -1484,7 +1537,6 @@ class SubFactoryTestCase(unittest.TestCase):
         class TestObjectFactory(factory.Factory):
             class Meta:
                 model = TestObject
-
 
         class OtherTestObject(object):
             def __init__(self, **kwargs):
@@ -1528,7 +1580,8 @@ class SubFactoryTestCase(unittest.TestCase):
             number = factory.Sequence(lambda n: n)
             book__author__country = factory.LazyAttribute(lambda o: 'FR')
 
-        c = ChapterFactory()
+        chapter = ChapterFactory()
+        self.assertEquals('FR', chapter.book.author.country)
 
     def test_nested_sub_factory(self):
         """Test nested sub-factories."""
@@ -1583,8 +1636,10 @@ class SubFactoryTestCase(unittest.TestCase):
             class Meta:
                 model = TestObject
 
-            wrap = factory.SubFactory(WrappingTestObjectFactory,
-                    wrapped__two=factory.SubFactory(TestObjectFactory, four=4))
+            wrap = factory.SubFactory(
+                WrappingTestObjectFactory,
+                wrapped__two=factory.SubFactory(TestObjectFactory, four=4),
+            )
 
         outer = OuterWrappingTestObjectFactory.build()
         self.assertEqual(outer.wrap.wrapped.two.four, 4)
@@ -1734,10 +1789,18 @@ class SubFactoryTestCase(unittest.TestCase):
                 model = OuterMost
 
             foo = 30
-            side_a = factory.SubFactory(SideAFactory,
-                inner_from_a__a=factory.ContainerAttribute(lambda obj, containers: containers[1].foo * 2))
-            side_b = factory.SubFactory(SideBFactory,
-                inner_from_b=factory.ContainerAttribute(lambda obj, containers: containers[0].side_a.inner_from_a))
+            side_a = factory.SubFactory(
+                SideAFactory,
+                inner_from_a__a=factory.ContainerAttribute(
+                    lambda obj, containers: containers[1].foo * 2,
+                )
+            )
+            side_b = factory.SubFactory(
+                SideBFactory,
+                inner_from_b=factory.ContainerAttribute(
+                    lambda obj, containers: containers[0].side_a.inner_from_a,
+                )
+            )
 
         outer = OuterMostFactory.build()
         self.assertEqual(outer.foo, 30)
@@ -1745,7 +1808,7 @@ class SubFactoryTestCase(unittest.TestCase):
         self.assertEqual(outer.side_a.inner_from_a.a, outer.foo * 2)
         self.assertEqual(outer.side_a.inner_from_a.b, 20)
 
-        outer = OuterMostFactory.build(side_a__inner_from_a__b = 4)
+        outer = OuterMostFactory.build(side_a__inner_from_a__b=4)
         self.assertEqual(outer.foo, 30)
         self.assertEqual(outer.side_a.inner_from_a, outer.side_b.inner_from_b)
         self.assertEqual(outer.side_a.inner_from_a.a, outer.foo * 2)
@@ -2211,7 +2274,7 @@ class PostGenerationTestCase(unittest.TestCase):
 
             bar = factory.PostGeneration(my_lambda)
 
-        obj = TestObjectFactory.build(bar=42, bar__foo=13)
+        TestObjectFactory.build(bar=42, bar__foo=13)
 
     def test_post_generation_override_with_extra(self):
         class TestObjectFactory(factory.Factory):
@@ -2244,10 +2307,7 @@ class PostGenerationTestCase(unittest.TestCase):
         obj = OtherTestObjectFactory.build()
         self.assertEqual(1 + 1 * 4, obj.one)
 
-
     def test_post_generation_method_call(self):
-        calls = []
-
         class TestObject(object):
             def __init__(self, one=None, two=None):
                 self.one = one
@@ -2341,6 +2401,7 @@ class PostGenerationTestCase(unittest.TestCase):
 
     def test_related_factory_no_name(self):
         relateds = []
+
         class TestRelatedObject(object):
             def __init__(self, obj=None, one=None, two=None):
                 relateds.append(self)
@@ -2404,7 +2465,9 @@ class PostGenerationTestCase(unittest.TestCase):
                 model = TestObject
             one = 3
             two = 2
-            three = factory.RelatedFactory(TestRelatedObjectFactory, 'obj',
+            three = factory.RelatedFactory(
+                TestRelatedObjectFactory,
+                'obj',
                 two=factory.SelfAttribute('obj.two'),
             )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,38 +34,50 @@ class ExtractDictTestCase(unittest.TestCase):
 
     def test_one_key_excluded(self):
         d = {'foo': 13, 'foo__baz': 42, '__foo': 1}
-        self.assertEqual({},
-            utils.extract_dict('foo', d, pop=False, exclude=('foo__baz',)))
+        self.assertEqual(
+            {},
+            utils.extract_dict('foo', d, pop=False, exclude=('foo__baz',)),
+        )
         self.assertEqual(42, d['foo__baz'])
 
-        self.assertEqual({},
-            utils.extract_dict('foo', d, pop=True, exclude=('foo__baz',)))
+        self.assertEqual(
+            {},
+            utils.extract_dict('foo', d, pop=True, exclude=('foo__baz',)),
+        )
         self.assertIn('foo__baz', d)
 
     def test_many_keys(self):
         d = {'foo': 13, 'foo__baz': 42, 'foo__foo__bar': 2, 'foo__bar': 3, '__foo': 1}
-        self.assertEqual({'foo__bar': 2, 'bar': 3, 'baz': 42},
-            utils.extract_dict('foo', d, pop=False))
+        self.assertEqual(
+            {'foo__bar': 2, 'bar': 3, 'baz': 42},
+            utils.extract_dict('foo', d, pop=False),
+        )
         self.assertEqual(42, d['foo__baz'])
         self.assertEqual(3, d['foo__bar'])
         self.assertEqual(2, d['foo__foo__bar'])
 
-        self.assertEqual({'foo__bar': 2, 'bar': 3, 'baz': 42},
-            utils.extract_dict('foo', d, pop=True))
+        self.assertEqual(
+            {'foo__bar': 2, 'bar': 3, 'baz': 42},
+            utils.extract_dict('foo', d, pop=True),
+        )
         self.assertNotIn('foo__baz', d)
         self.assertNotIn('foo__bar', d)
         self.assertNotIn('foo__foo__bar', d)
 
     def test_many_keys_excluded(self):
         d = {'foo': 13, 'foo__baz': 42, 'foo__foo__bar': 2, 'foo__bar': 3, '__foo': 1}
-        self.assertEqual({'foo__bar': 2, 'baz': 42},
-            utils.extract_dict('foo', d, pop=False, exclude=('foo__bar', 'bar')))
+        self.assertEqual(
+            {'foo__bar': 2, 'baz': 42},
+            utils.extract_dict('foo', d, pop=False, exclude=('foo__bar', 'bar')),
+        )
         self.assertEqual(42, d['foo__baz'])
         self.assertEqual(3, d['foo__bar'])
         self.assertEqual(2, d['foo__foo__bar'])
 
-        self.assertEqual({'foo__bar': 2, 'baz': 42},
-            utils.extract_dict('foo', d, pop=True, exclude=('foo__bar', 'bar')))
+        self.assertEqual(
+            {'foo__bar': 2, 'baz': 42},
+            utils.extract_dict('foo', d, pop=True, exclude=('foo__bar', 'bar')),
+        )
         self.assertNotIn('foo__baz', d)
         self.assertIn('foo__bar', d)
         self.assertNotIn('foo__foo__bar', d)
@@ -76,55 +88,75 @@ class MultiExtractDictTestCase(unittest.TestCase):
         self.assertEqual({'foo': {}}, utils.multi_extract_dict(['foo'], {}))
 
     def test_unused_key(self):
-        self.assertEqual({'foo': {}},
-            utils.multi_extract_dict(['foo'], {'bar__baz': 42}))
-        self.assertEqual({'foo': {}, 'baz': {}},
-            utils.multi_extract_dict(['foo', 'baz'], {'bar__baz': 42}))
+        self.assertEqual(
+            {'foo': {}},
+            utils.multi_extract_dict(['foo'], {'bar__baz': 42}),
+        )
+        self.assertEqual(
+            {'foo': {}, 'baz': {}},
+            utils.multi_extract_dict(['foo', 'baz'], {'bar__baz': 42}),
+        )
 
     def test_no_key(self):
         self.assertEqual({}, utils.multi_extract_dict([], {'bar__baz': 42}))
 
     def test_empty_key(self):
-        self.assertEqual({'': {}},
-            utils.multi_extract_dict([''], {'foo': 13, 'bar__baz': 42}))
+        self.assertEqual(
+            {'': {}},
+            utils.multi_extract_dict([''], {'foo': 13, 'bar__baz': 42}),
+        )
 
         d = {'foo': 13, 'bar__baz': 42, '__foo': 1}
-        self.assertEqual({'': {'foo': 1}},
-            utils.multi_extract_dict([''], d))
+        self.assertEqual(
+            {'': {'foo': 1}},
+            utils.multi_extract_dict([''], d),
+        )
         self.assertNotIn('__foo', d)
 
     def test_one_extracted(self):
         d = {'foo': 13, 'foo__baz': 42, '__foo': 1}
-        self.assertEqual({'foo': {'baz': 42}},
-            utils.multi_extract_dict(['foo'], d, pop=False))
+        self.assertEqual(
+            {'foo': {'baz': 42}},
+            utils.multi_extract_dict(['foo'], d, pop=False),
+        )
         self.assertEqual(42, d['foo__baz'])
 
-        self.assertEqual({'foo': {'baz': 42}},
-            utils.multi_extract_dict(['foo'], d, pop=True))
+        self.assertEqual(
+            {'foo': {'baz': 42}},
+            utils.multi_extract_dict(['foo'], d, pop=True),
+        )
         self.assertNotIn('foo__baz', d)
 
     def test_many_extracted(self):
         d = {'foo': 13, 'foo__baz': 42, 'foo__foo__bar': 2, 'foo__bar': 3, '__foo': 1}
-        self.assertEqual({'foo': {'foo__bar': 2, 'bar': 3, 'baz': 42}},
-            utils.multi_extract_dict(['foo'], d, pop=False))
+        self.assertEqual(
+            {'foo': {'foo__bar': 2, 'bar': 3, 'baz': 42}},
+            utils.multi_extract_dict(['foo'], d, pop=False),
+        )
         self.assertEqual(42, d['foo__baz'])
         self.assertEqual(3, d['foo__bar'])
         self.assertEqual(2, d['foo__foo__bar'])
 
-        self.assertEqual({'foo': {'foo__bar': 2, 'bar': 3, 'baz': 42}},
-            utils.multi_extract_dict(['foo'], d, pop=True))
+        self.assertEqual(
+            {'foo': {'foo__bar': 2, 'bar': 3, 'baz': 42}},
+            utils.multi_extract_dict(['foo'], d, pop=True),
+        )
         self.assertNotIn('foo__baz', d)
         self.assertNotIn('foo__bar', d)
         self.assertNotIn('foo__foo__bar', d)
 
     def test_many_keys_one_extracted(self):
         d = {'foo': 13, 'foo__baz': 42, '__foo': 1}
-        self.assertEqual({'foo': {'baz': 42}, 'baz': {}},
-            utils.multi_extract_dict(['foo', 'baz'], d, pop=False))
+        self.assertEqual(
+            {'foo': {'baz': 42}, 'baz': {}},
+            utils.multi_extract_dict(['foo', 'baz'], d, pop=False),
+        )
         self.assertEqual(42, d['foo__baz'])
 
-        self.assertEqual({'foo': {'baz': 42}, 'baz': {}},
-            utils.multi_extract_dict(['foo', 'baz'], d, pop=True))
+        self.assertEqual(
+            {'foo': {'baz': 42}, 'baz': {}},
+            utils.multi_extract_dict(['foo', 'baz'], d, pop=True),
+        )
         self.assertNotIn('foo__baz', d)
 
     def test_many_keys_many_extracted(self):
@@ -209,12 +241,10 @@ class ImportObjectTestCase(unittest.TestCase):
         self.assertEqual(d, imported)
 
     def test_unknown_attribute(self):
-        self.assertRaises(AttributeError, utils.import_object,
-            'datetime', 'foo')
+        self.assertRaises(AttributeError, utils.import_object, 'datetime', 'foo')
 
     def test_invalid_module(self):
-        self.assertRaises(ImportError, utils.import_object,
-            'this-is-an-invalid-module', '__name__')
+        self.assertRaises(ImportError, utils.import_object, 'this-is-an-invalid-module', '__name__')
 
 
 class LogPPrintTestCase(unittest.TestCase):
@@ -365,4 +395,3 @@ class ResetableIteratorTestCase(unittest.TestCase):
         self.assertEqual(2, next(iterator))
         self.assertEqual(3, next(iterator))
         self.assertEqual(4, next(iterator))
-

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
 # Copyright: See the LICENSE file.
 
-import datetime
 import functools
 import warnings
 
 import factory
 
-from .compat import mock
 from . import alter_time
 
 
@@ -33,7 +31,7 @@ class MultiModulePatcher(object):
 
     def __enter__(self):
         for patcher in self.patchers:
-            mocked_symbol = patcher.start()
+            patcher.start()
 
     def __exit__(self, exc_type=None, exc_val=None, exc_tb=None):
         for patcher in self.patchers:


### PR DESCRIPTION
Following the same standard as the project and the broader Python
community makes maintenance easier. Linting can also reveal real
mistakes, such as `test_auto_sequence` being shadowed.