### PR TITLE
Don't test if Django is present in django tests

### DIFF
--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -119,16 +119,14 @@ class WithFileFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.WithFile
 
-    if django is not None:
-        afile = factory.django.FileField()
+    afile = factory.django.FileField()
 
 
 class WithImageFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.WithImage
 
-    if django is not None:
-        animage = factory.django.ImageField()
+    animage = factory.django.ImageField()
 
 
 class WithSignalsFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
Django is a test requirement, there are import at the top of the
test_django.py file, there's not need to test if django is defined in
the factories.