### PR TITLE
Trim trailing white space throughout the project

### DIFF
--- a/docs/fuzzy.rst
+++ b/docs/fuzzy.rst
@@ -75,14 +75,14 @@ FuzzyChoice
 
               This allows passing in, for instance, a Django queryset that will
               only hit the database during the database, not at import time.
-    
+
     .. warning:: When using Python2 and list comprehension, use private variable
                  names as in:
-                 
+
                  `[_x.name for _x in items]`
-                 
+
                  instead of:
-                 
+
                  `[x.name for x in items]`
 
     .. attribute:: choices

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,4 +22,3 @@ Contents, indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -361,5 +361,3 @@ Calling a :class:`~factory.Factory` subclass will provide an object through the 
 
 
 The default strategy can be changed by setting the ``class Meta`` :attr:`~factory.FactoryOptions.strategy` attribute.
-
-

--- a/docs/orms.rst
+++ b/docs/orms.rst
@@ -322,25 +322,25 @@ To work, this class needs an `SQLAlchemy`_ session object affected to the :attr:
     .. attribute:: sqlalchemy_session_persistence
 
         Control the action taken by sqlalchemy session at the end of a create call.
-        
+
         Valid values are:
-        
+
         * ``None``: do nothing
         * ``'flush'``: perform a session :meth:`~sqlalchemy.orm.session.Session.flush`
         * ``'commit'``: perform a session :meth:`~sqlalchemy.orm.session.Session.commit`
-        
+
         The default value is ``None``.
-        
+
         If ``force_flush`` is set to ``True``, it overrides this option.
 
     .. attribute:: force_flush
 
         Force a session ``flush()`` at the end of :func:`~factory.alchemy.SQLAlchemyModelFactory._create()`.
-        
+
         .. note::
-        
+
             This option is deprecated. Use ``sqlalchemy_session_persistence`` instead.
-    
+
 A (very) simple example:
 
 .. code-block:: python

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -2034,5 +2034,3 @@ extracting instances from them:
     :param int size: Number of instances to generate
     :param kwargs: Declarations to use for the generated factory
     :param FACTORY_CLASS: Alternate base class (instead of :class:`Factory`)
-
-

--- a/examples/django_demo/generic_foreignkey/models.py
+++ b/examples/django_demo/generic_foreignkey/models.py
@@ -14,4 +14,3 @@ class TaggedItem(models.Model):
 
     def __str__(self):  # __unicode__ on Python 2
         return self.tag
-


### PR DESCRIPTION
Many editors clean up trailing white space on save. By removing it all in one go, it helps keep future diffs cleaner by avoiding spurious white space changes on unrelated lines.