### PR TITLE
Remove unnecessary imports of submodules

### DIFF
--- a/docs/orms.rst
+++ b/docs/orms.rst
@@ -193,7 +193,6 @@ To work around this problem, use the :meth:`mute_signals()` decorator/context ma
     # foo/factories.py
 
     import factory
-    import factory.django
 
     from . import models
     from . import signals
@@ -429,7 +428,6 @@ Here is an example layout:
     # myproject/factories.py
 
     import factory
-    import factory.alchemy
 
     from . import models
     from .test import common

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -30,7 +30,6 @@ except ImportError:  # pragma: no cover
         Image = None
 
 import factory  # noqa: E402
-import factory.django  # noqa: E402
 
 from . import testdata  # noqa: E402
 from .compat import mock  # noqa: E402


### PR DESCRIPTION
The `django` and `alchemy` modules are imported into the `factory` namespace in `factory/__init__.py`. No need to import explicitly in other files.