### PR TITLE
Prefer io.BytesIO; available on all supported Pythons

### DIFF
--- a/factory/compat.py
+++ b/factory/compat.py
@@ -13,8 +13,6 @@ if PY2:  # pragma: no cover
     def is_string(obj):
         return isinstance(obj, (str, unicode))  # noqa
 
-    from StringIO import StringIO as BytesIO  # noqa
-
     def force_text(str_or_unicode):
         if isinstance(str_or_unicode, unicode):  # noqa
             return str_or_unicode
@@ -23,8 +21,6 @@ if PY2:  # pragma: no cover
 else:  # pragma: no cover
     def is_string(obj):
         return isinstance(obj, str)
-
-    from io import BytesIO  # noqa
 
     def force_text(text):
         return text

--- a/factory/django.py
+++ b/factory/django.py
@@ -7,6 +7,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import io
 import os
 import logging
 import functools
@@ -23,7 +24,7 @@ except ImportError as e:  # pragma: no cover
 from . import base
 from . import declarations
 from . import errors
-from .compat import BytesIO, is_string
+from .compat import is_string
 
 logger = logging.getLogger('factory.generate')
 
@@ -248,7 +249,7 @@ class ImageField(FileField):
         image_format = params.get('format', 'JPEG')
 
         thumb = Image.new('RGB', (width, height), color)
-        thumb_io = BytesIO()
+        thumb_io = io.BytesIO()
         thumb.save(thumb_io, format=image_format)
         return thumb_io.getvalue()
 

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -3,6 +3,7 @@
 
 """Tests for factory_boy/Django interactions."""
 
+import io
 import os
 
 import django
@@ -29,7 +30,6 @@ except ImportError:  # pragma: no cover
 
 import factory  # noqa: E402
 import factory.django  # noqa: E402
-from factory.compat import BytesIO  # noqa: E402
 
 from . import testdata  # noqa: E402
 from .compat import unittest, mock  # noqa: E402
@@ -754,7 +754,7 @@ class DjangoImageFieldTestCase(django_test.TestCase):
 
     def _img_test_func(self):
         img = Image.new('RGB', (32, 32), 'blue')
-        img_io = BytesIO()
+        img_io = io.BytesIO()
         img.save(img_io, format='JPEG')
         img_io.seek(0)
         return img_io


### PR DESCRIPTION
Removes unnecessary `compat.py` workaround.