### PR TITLE
Remove unused workaround for Python 2.6's unittest2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@
 import codecs
 import os
 import re
-import sys
 
 from setuptools import setup
 
@@ -21,12 +20,6 @@ def get_version(package_name):
             if match:
                 return match.groups()[0]
     return '0.1.0'
-
-
-if sys.version_info[0:2] < (2, 7):  # pragma: no cover
-    test_loader = 'unittest2:TestLoader'
-else:
-    test_loader = 'unittest:TestLoader'
 
 
 PACKAGE = 'factory'
@@ -74,5 +67,5 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     test_suite='',
-    test_loader=test_loader,
+    test_loader='unittest:TestLoader',
 )

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -7,11 +7,6 @@ import sys
 
 is_python2 = (sys.version_info[0] == 2)
 
-if sys.version_info[0:2] < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest  # noqa: F401
-
 if is_python2:
     import StringIO as io
 else:

--- a/tests/test_alchemy.py
+++ b/tests/test_alchemy.py
@@ -4,9 +4,9 @@
 """Tests for factory_boy/SQLAlchemy interactions."""
 
 import factory
-from .compat import unittest
 from .compat import mock
 import warnings
+import unittest
 
 from factory.alchemy import SQLAlchemyModelFactory
 from .alchemyapp import models

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # Copyright: See the LICENSE file.
 
+import unittest
+
 from factory import base
 from factory import declarations
 from factory import enums
 from factory import errors
-
-from .compat import unittest
 
 
 class TestObject(object):

--- a/tests/test_declarations.py
+++ b/tests/test_declarations.py
@@ -2,13 +2,14 @@
 # Copyright: See the LICENSE file.
 
 import datetime
+import unittest
 
 from factory import base
 from factory import declarations
 from factory import errors
 from factory import helpers
 
-from .compat import mock, unittest
+from .compat import mock
 from . import utils
 
 

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -4,6 +4,7 @@
 """Tests for factory_boy/Django interactions."""
 
 import os
+import unittest
 
 import django
 
@@ -32,7 +33,7 @@ import factory.django  # noqa: E402
 from factory.compat import BytesIO  # noqa: E402
 
 from . import testdata  # noqa: E402
-from .compat import unittest, mock  # noqa: E402
+from .compat import mock  # noqa: E402
 
 
 test_state = {}

--- a/tests/test_docs_internals.py
+++ b/tests/test_docs_internals.py
@@ -21,12 +21,11 @@
 """Tests for the docs/internals module."""
 
 import datetime
+import unittest
 
 import factory
 import factory.fuzzy
 from factory.compat import UTC
-
-from .compat import unittest
 
 
 class User(object):

--- a/tests/test_fuzzy.py
+++ b/tests/test_fuzzy.py
@@ -4,13 +4,14 @@
 
 import datetime
 import decimal
+import unittest
 import warnings
 
 from factory import compat
 from factory import fuzzy
 from factory import random
 
-from .compat import mock, unittest
+from .compat import mock
 from . import utils
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,10 +2,11 @@
 # Copyright: See the LICENSE file.
 
 import logging
+import unittest
 
 from factory import helpers
 
-from .compat import io, unittest
+from .compat import io
 
 
 class DebugTest(unittest.TestCase):

--- a/tests/test_mongoengine.py
+++ b/tests/test_mongoengine.py
@@ -3,10 +3,10 @@
 
 """Tests for factory_boy/MongoEngine interactions."""
 
+import unittest
+
 import factory
 import os
-from .compat import unittest
-
 
 import mongoengine
 

--- a/tests/test_using.py
+++ b/tests/test_using.py
@@ -8,11 +8,12 @@ import collections
 import datetime
 import os
 import sys
+import unittest
 
 import factory
 from factory import errors
 
-from .compat import is_python2, unittest
+from .compat import is_python2
 from . import utils
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,12 +3,12 @@
 
 from __future__ import unicode_literals
 
-
 import itertools
+import unittest
 
 from factory import utils
 
-from .compat import is_python2, unittest
+from .compat import is_python2
 
 
 class ExtractDictTestCase(unittest.TestCase):


### PR DESCRIPTION
Python 2.6 hasn't been supported since at least 5071655e34ba7d51e42454a0fa0463bc4d7c9e92.