### PR TITLE
Replace deprecated assertEquals with assertEqual

### DIFF
--- a/tests/test_using.py
+++ b/tests/test_using.py
@@ -1582,7 +1582,7 @@ class SubFactoryTestCase(unittest.TestCase):
             book__author__country = factory.LazyAttribute(lambda o: 'FR')
 
         chapter = ChapterFactory()
-        self.assertEquals('FR', chapter.book.author.country)
+        self.assertEqual('FR', chapter.book.author.country)
 
     def test_nested_sub_factory(self):
         """Test nested sub-factories."""


### PR DESCRIPTION
Fixes warning emitted during tests. For details, see:

https://docs.python.org/3/library/unittest.html#deprecated-aliases