### PR TITLE
Add direct link to Faker documentation.

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -692,6 +692,8 @@ Faker
         >>> user.name
         'Lucy Cechtelar'
 
+    Visit the `faker documentation <https://faker.readthedocs.io/en/latest//>`_
+    for a full reference of Faker attributes.
 
     .. attribute:: locale
 


### PR DESCRIPTION
Quite often when I need a fake attribute I find myself looking at the Factory Boy docs, then realizing I really wanted the Faker docs. This PR is a convenience to be able to quickly access those without having to google for them.

Thanks for maintaining this great library!