### PR TITLE
Change Faker link from PyPI to Read The Docs.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,7 +187,7 @@ Realistic, random values
 """"""""""""""""""""""""
 
 Demos look better with random yet realistic values; and those realistic values can also help discover bugs.
-For this, factory_boy relies on the excellent `faker <https://pypi.org/project/Faker/>`_ library:
+For this, factory_boy relies on the excellent `faker <https://faker.readthedocs.io/en/latest/>`_ library:
 
 .. code-block:: python
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -675,7 +675,7 @@ Faker
     In order to easily define realistic-looking factories,
     use the :class:`Faker` attribute declaration.
 
-    This is a wrapper around `faker <https://pypi.org/project/Faker/>`_;
+    This is a wrapper around `faker <https://faker.readthedocs.io/en/latest/>`_;
     its argument is the name of a ``faker`` provider:
 
     .. code-block:: python


### PR DESCRIPTION
Replaces #520 per feedback from @francoisfreitag @jeffwidman. Thank you for the feedback - I prefer this solution as well :).