### PR TITLE
Turn sphinx warnings into errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ coverage:
 
 # DOC: Compile the documentation
 doc:
-	$(MAKE) -C $(DOC_DIR) html
+	$(MAKE) -C $(DOC_DIR) SPHINXOPTS=-W html
 
 
 # DOC: Show this help message


### PR DESCRIPTION
There are currently no warning when building the documentation. Turning
warning to errors highlights issues and prevent them from getting into
the code base.