### PR TITLE
Follow most recent version of Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,10 +60,14 @@ matrix:
       sudo: true
 
     # Linting
-    - python: "3.6"
+    - python: "3.7"
       env: TOXENV=examples
-    - python: "3.6"
+      dist: xenial
+      sudo: true
+    - python: "3.7"
       env: TOXENV=lint
+      dist: xenial
+      sudo: true
   allow_failures:
     # Django 2.0
     - python: "nightly"

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ whitelist_externals = make
 commands = make test
 
 [testenv:examples]
-basepython = python3.6
+basepython = python3.7
 deps =
     -rrequirements_test.txt
     -rexamples/requirements.txt


### PR DESCRIPTION
Python 3.7 is now the latest stable release of Python, follow upstream
to benefit from latest features and improvements.

#525 and #529 need to be updated if this PR is merged first.
This PR needs to be updated if any of both PRs are merged.