### PR TITLE
Fix error in documentation for _create method

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -311,6 +311,7 @@ Attributes and methods
                 class Meta:
                     abstract = True  # Optional
 
+                @classmethod
                 def _create(cls, model_class, *args, **kwargs):
                     obj = model_class(*args, **kwargs)
                     obj.save()


### PR DESCRIPTION
`_create` must be a classmethod