### PR TITLE
Fix final List order for lists longer than 10 items.

### DIFF
--- a/factory/base.py
+++ b/factory/base.py
@@ -733,7 +733,10 @@ class BaseListFactory(Factory):
             raise ValueError(
                 "ListFactory %r does not support Meta.inline_args.", cls)
 
-        values = [v for k, v in sorted(kwargs.items())]
+        # When support for Python <3.6 is dropped sorting will no longer be required
+        # because dictionaries will already be ordered, this can then be changed to:
+        # values = kwargs.values()
+        values = [v for k, v in sorted(kwargs.items(), key=lambda item: int(item[0]))]
         return model_class(values)
 
     @classmethod

--- a/tests/test_using.py
+++ b/tests/test_using.py
@@ -2725,6 +2725,15 @@ class ListTestCase(unittest.TestCase):
         o = TestObjectFactory()
         self.assertEqual([1], o.one)
 
+    def test_long_list(self):
+        class TestObjectFactory(factory.Factory):
+            class Meta:
+                model = TestObject
+            one = factory.List(list(range(100)))
+
+        o = TestObjectFactory()
+        self.assertEqual(list(range(100)), o.one)
+
     def test_sequence_list(self):
         class TestObjectFactory(factory.Factory):
             class Meta:


### PR DESCRIPTION
When creating a factory with a `List` the list items are converted into a dict, to allow easily overwriting specific items when calling the factory. For keys of the dictionary the string-converted indexes are used. When finally converted back into a list the items of the dict are sorted by the keys. However, since these are strings `'10'` comes before `'2'`. In order to preserve the correct order the keys should be converted back to integers when sorting. For Python 3.7+ (and 3.6) dictionaries are already ordered, so not additional sorting would be required, but since older Python versions are also supported sorting is still required.

I fixed it by adding a sorting key to the `sorted` function. A test is also added which checks if the order for long lists are preserved.

This does assume that classes such as `List` use param keys which are integers (but as strings).

So when using this:
`factory.List(list(range(100)))`
The old result would be:
`[0, 1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, …, 99]`
The new result is:
`[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, …, 99]`