### PR TITLE
django: Improve compatibility with Django 2.1

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,11 @@ ChangeLog
 - Added support for Python 3.7
 - Added support for Django 2.1
 
+*Bugfix:*
+
+    - Fix assignment of many-to-many or many-to-one relations in Django factories for Django>=2.0 (see
+      django/django@ed25124)
+
 
 2.11.1 (2018-05-05)
 -------------------

--- a/tests/djapp/models.py
+++ b/tests/djapp/models.py
@@ -70,6 +70,15 @@ class PointerModel(models.Model):
     )
 
 
+class WithManyToManyModel(models.Model):
+    baz = models.CharField(max_length=20)
+    pointers = models.ManyToManyField(
+        PointerModel,
+        related_name='with_many_to_many_models',
+        null=True,
+    )
+
+
 class WithDefaultValue(models.Model):
     foo = models.CharField(max_length=20, default='')
 

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -387,11 +387,24 @@ class DjangoRelatedFieldTestCase(django_test.TestCase):
         class PointedRelatedExtraFactory(PointedRelatedFactory):
             pointer__bar = 'extra_new_bar'
 
+        class WithManyToManyFactory(factory.django.DjangoModelFactory):
+            class Meta:
+                model = models.WithManyToManyModel
+            baz = 'baz'
+
+        class WithManyToManyGetOrCreateFactory(factory.django.DjangoModelFactory):
+            class Meta:
+                model = models.WithManyToManyModel
+                django_get_or_create = ['baz']
+            baz = 'baz'
+
         cls.PointedFactory = PointedFactory
         cls.PointerFactory = PointerFactory
         cls.PointedRelatedFactory = PointedRelatedFactory
         cls.PointerExtraFactory = PointerExtraFactory
         cls.PointedRelatedExtraFactory = PointedRelatedExtraFactory
+        cls.WithManyToManyFactory = WithManyToManyFactory
+        cls.WithManyToManyGetOrCreateFactory = WithManyToManyGetOrCreateFactory
 
     def test_create_pointed(self):
         pointed = self.PointedFactory()
@@ -437,6 +450,20 @@ class DjangoRelatedFieldTestCase(django_test.TestCase):
         self.assertEqual(pointed.foo, 'foo')
         self.assertEqual(pointed.pointer, models.PointerModel.objects.get())
         self.assertEqual(pointed.pointer.bar, 'extra_new_bar')
+
+    def test_create_with_many_to_many(self):
+        pointer = self.PointerFactory()
+        with_many_to_many = self.WithManyToManyFactory(pointers=[pointer])
+        self.assertEqual(with_many_to_many.baz, 'baz')
+        self.assertEqual(pointer, with_many_to_many.pointers.get())
+        self.assertEqual(with_many_to_many, pointer.with_many_to_many_models.get())
+
+    def test_get_or_create_with_many_to_many(self):
+        pointer = self.PointerFactory()
+        with_many_to_many = self.WithManyToManyGetOrCreateFactory(pointers=[pointer])
+        self.assertEqual(with_many_to_many.baz, 'baz')
+        self.assertEqual(pointer, with_many_to_many.pointers.get())
+        self.assertEqual(with_many_to_many, pointer.with_many_to_many_models.get())
 
 
 class DjangoFileFieldTestCase(django_test.TestCase):


### PR DESCRIPTION
Direct assignment on many_to_one or many_to_many sets is prohibed since
Django 2.0 (and deprecated since 1.10)

The test is in a separated commit so that you can test that the fix really fixes something.
I'll squash the two commits later.