### PR TITLE
Use 'dist: xenial' on Travis to simplify configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo: false
 language: python
 cache: pip
@@ -29,8 +30,6 @@ matrix:
       env: TOXENV=py36-django20-alchemy12-mongoengine015
     - python: "3.7"
       env: TOXENV=py37-django20-alchemy12-mongoengine015
-      dist: xenial
-      sudo: true
 
     # Django 2.1
     - python: "3.5"
@@ -39,56 +38,38 @@ matrix:
       env: TOXENV=py36-django21-alchemy12-mongoengine015
     - python: "3.7"
       env: TOXENV=py37-django21-alchemy12-mongoengine015
-      dist: xenial
-      sudo: true
 
     # Pypy
-    - python: "pypy"
+    - python: "pypy2.7-6.0"
       env: TOXENV=pypy-django111-alchemy12-mongoengine015
-    - python: "pypy3"
+    - python: "pypy3.5-6.0"
       env: TOXENV=pypy3-django20-alchemy12-mongoengine015
 
     # Django 2.0
     - python: "nightly"
       env: TOXENV=pynightly-django20-alchemy12-mongoengine015
-      dist: xenial
-      sudo: true
     # Django 2.1
     - python: "nightly"
       env: TOXENV=pynightly-django21-alchemy12-mongoengine015
-      dist: xenial
-      sudo: true
 
     # Documentation
     - python: "3.7"
       env: TOXENV=docs
-      dist: xenial
-      sudo: true
     - python: "3.7"
       env: TOXENV=linkcheck
-      dist: xenial
-      sudo: true
 
     # Linting
     - python: "3.7"
       env: TOXENV=examples
-      dist: xenial
-      sudo: true
     - python: "3.7"
       env: TOXENV=lint
-      dist: xenial
-      sudo: true
   allow_failures:
     # Django 2.0
     - python: "nightly"
       env: TOXENV=pynightly-django20-alchemy12-mongoengine015
-      dist: xenial
-      sudo: true
     # Django 2.1
     - python: "nightly"
       env: TOXENV=pynightly-django21-alchemy12-mongoengine015
-      dist: xenial
-      sudo: true
 
 services:
   - mongodb


### PR DESCRIPTION
Allows using Python version 3.7 without sudo declarations.

Travis officially added support for Xenial on 2018-11-08.

https://blog.travis-ci.com/2018-11-08-xenial-release

Using PyPy on xenial requires an explicit version, see:

https://travis-ci.community/t/pypy-2-7-on-xenial/889