### PR TITLE
Clarify first argument of post_generation decorated

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1777,7 +1777,7 @@ A decorator is also provided, decorating a single method accepting the same
         login = 'john'
 
         @factory.post_generation
-        def mbox(self, create, extracted, **kwargs):
+        def mbox(obj, create, extracted, **kwargs):
             if not create:
                 return
             path = extracted or os.path.join('/tmp/mbox/', self.login)


### PR DESCRIPTION
`self` usually means the current class instance, which in this case would be `UserFactory`, instead of `User`. Replacing with `obj`, which makes it clear that the arguments of the decorated method are indeed the same as for `PostGeneration`.