### PR TITLE
Django Factory: Properly clean up FileField FD

### DIFF
--- a/factory/django.py
+++ b/factory/django.py
@@ -198,8 +198,8 @@ class FileField(declarations.ParameteredAttribute):
 
         if params.get('from_path'):
             path = params['from_path']
-            f = open(path, 'rb')
-            content = django_files.File(f, name=path)
+            with open(path, 'rb') as f:
+                content = django_files.File(f, name=path)
 
         elif params.get('from_file'):
             f = params['from_file']


### PR DESCRIPTION
Python doesn't like unclosed files, so using open as a context manager here solves that issue.