### PR TITLE
Add support for getter argument in FuzzyChoice

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,8 +4,12 @@ ChangeLog
 2.11.2 (unreleased)
 -------------------
 
-- Added support for Python 3.7
-- Added support for Django 2.1
+*New:*
+
+    - Added support for Python 3.7
+    - Added support for Django 2.1
+    - Add :attr:`~factory.fuzzy.FuzzyChoice.getter` to :class:`~factory.fuzzy.FuzzyChoice` that mimics
+      the behavior of ``getter`` in :class:`~factory.Iterator`
 
 
 2.11.1 (2018-05-05)

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -486,6 +486,24 @@ In order to get a dict, we'll just have to swap the model; the easiest way is to
     >>> factory.build(dict, FACTORY_CLASS=UserFactory)
     {'first_name': "Agent 001", 'username': 'john_doe'}
 
+
+Fuzzying Django model field choices
+-----------------------------------
+
+When defining a :class:`~factory.fuzzy.FuzzyChoice` you can reuse the same choice list from the model field descriptor.
+
+Use the ``getter`` kwarg to select the first element from each choice tuple.
+
+.. code-block:: python
+
+    class UserFactory(factory.Factory):
+        class Meta:
+            model = User
+
+        # CATEGORY_CHOICES is a list of (key, title) tuples
+        category = factory.fuzzy.FuzzyChoice(User.CATEGORY_CHOICES, getter=lambda c: c[0])
+
+
 Django models with `GenericForeignKeys`
 ---------------------------------------
 

--- a/factory/fuzzy.py
+++ b/factory/fuzzy.py
@@ -116,17 +116,22 @@ class FuzzyChoice(BaseFuzzyAttribute):
     Args:
         choices (iterable): An iterable yielding options; will only be unrolled
             on the first call.
+        getter (callable or None): a function to parse returned values
     """
 
-    def __init__(self, choices, **kwargs):
+    def __init__(self, choices, getter=None, **kwargs):
         self.choices = None
         self.choices_generator = choices
+        self.getter = getter
         super(FuzzyChoice, self).__init__(**kwargs)
 
     def fuzz(self):
         if self.choices is None:
             self.choices = list(self.choices_generator)
-        return random.randgen.choice(self.choices)
+        value = random.randgen.choice(self.choices)
+        if self.getter is None:
+            return value
+        return self.getter(value)
 
 
 class FuzzyInteger(BaseFuzzyAttribute):

--- a/tests/test_fuzzy.py
+++ b/tests/test_fuzzy.py
@@ -76,6 +76,12 @@ class FuzzyChoiceTestCase(unittest.TestCase):
         self.assertIn(res, [1, 2, 3])
         self.assertTrue(opts.unrolled)
 
+    def test_getter(self):
+        options = [('a', 1), ('b', 2), ('c', 3)]
+        d = fuzzy.FuzzyChoice(options, getter=lambda x: x[1])
+        res = utils.evaluate_declaration(d)
+        self.assertIn(res, [1, 2, 3])
+
 
 class FuzzyIntegerTestCase(unittest.TestCase):
     def test_definition(self):


### PR DESCRIPTION
This mimics the behavior of getter in `factory.Iterator` and allows for easy fuzzy choices for Django ChoiceFields.