### PR TITLE
Make the example clearer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,12 @@ while only declaring the test-specific fields:
                 is_vip=True,
                 address=address,
             )
+            order = Order(
+                amount=200,
+                status='PAID',
+                customer=customer,
+                address=address
+            )
             # etc.
 
 factory_boy is designed to work well with various ORMs (Django, Mongo, SQLAlchemy),


### PR DESCRIPTION
The current example of "without FactoryBoy" does not actually create an order so the two examples do not seem like they are doing the same thing (because they aren't). My proposal is a bit more long-winded but that's the point of the example.