### PR TITLE
Skip factory_boy install for doc and lint CI builds

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+minversion = 1.9
 envlist =
     py{27,34,35,36,37}-django111-alchemy12-mongoengine015,
     py{34,35,36,37,nightly}-django20-alchemy12-mongoengine015,
@@ -29,6 +30,7 @@ commands = make test
 basepython = python3.7
 deps =
     -rrequirements_dev.txt
+skip_install = true
 
 whitelist_externals = make
 commands = make doc
@@ -45,6 +47,7 @@ commands = make example-test
 [testenv:linkcheck]
 deps =
     -rrequirements_dev.txt
+skip_install = true
 
 whitelist_externals = make
 commands = make linkcheck
@@ -53,6 +56,7 @@ commands = make linkcheck
 deps =
     flake8
     check_manifest
+skip_install = true
 
 whitelist_externals = make
 commands = make lint


### PR DESCRIPTION
These builds do not need the factory package, installing it is a waste
of time and resources.

The skip_install option was introduced with tox 1.9.