### PR TITLE
Run lint first on CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+    lint
     py{27,34,35,36,37}-django111-alchemy12-mongoengine015,
     py{34,35,36,37,nightly}-django20-alchemy12-mongoengine015,
     py{35,36,37,nightly}-django21-alchemy12-mongoengine015,
@@ -8,7 +9,6 @@ envlist =
     docs
     examples
     linkcheck
-    lint
 
 toxworkdir = {env:TOX_WORKDIR:.tox}
 


### PR DESCRIPTION
Gives quicker feedback if a change is not up to quality expectations.