### PR TITLE
Make locale argument of factory.Faker keyword-only

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ ChangeLog
       the behavior of ``getter`` in :class:`~factory.Iterator`
     - Make the ``extra_kwargs`` parameter of :meth:`~factory.faker.Faker.generate` optional
     - Add :class:`~factory.RelatedFactoryList` class for one-to-many support, thanks `Sean Harrington <https://github.com/seanharr11>`_.
+    - Make the `locale` argument for :class:`~factory.faker.Faker` keyword-only
 
 *Bugfix:*
 

--- a/factory/faker.py
+++ b/factory/faker.py
@@ -39,11 +39,11 @@ class Faker(declarations.BaseDeclaration):
     Usage:
         >>> foo = factory.Faker('name')
     """
-    def __init__(self, provider, locale=None, **kwargs):
+    def __init__(self, provider, **kwargs):
         super(Faker, self).__init__()
         self.provider = provider
         self.provider_kwargs = kwargs
-        self.locale = locale
+        self.locale = kwargs.pop('locale', None)
 
     def generate(self, extra_kwargs=None):
         kwargs = {}


### PR DESCRIPTION
Prevents users from declaring the attribute as `factory.Faker('first_name', 'es')` which could be mistaken for a positional argument to the underlying faker provider.

This change is NOT backward-compatible, but the required fix is really easy.