### PR TITLE
Fix a bug when overriding Params in a Trait

### DIFF
--- a/factory/declarations.py
+++ b/factory/declarations.py
@@ -545,6 +545,7 @@ class SimpleParameter(Parameter):
     def wrap(cls, value):
         if not isinstance(value, Parameter):
             return cls(value)
+        value.touch_creation_counter()
         return value
 
 

--- a/factory/utils.py
+++ b/factory/utils.py
@@ -98,13 +98,16 @@ class OrderedBase(object):
     def __init__(self, **kwargs):
         super(OrderedBase, self).__init__(**kwargs)
         if type(self) is not OrderedBase:
-            bases = type(self).__mro__
-            root = bases[bases.index(OrderedBase) - 1]
-            if not hasattr(root, self.CREATION_COUNTER_FIELD):
-                setattr(root, self.CREATION_COUNTER_FIELD, 0)
-            next_counter = getattr(self, self.CREATION_COUNTER_FIELD)
-            setattr(self, self.CREATION_COUNTER_FIELD, next_counter)
-            setattr(root, self.CREATION_COUNTER_FIELD, next_counter + 1)
+            self.touch_creation_counter()
+
+    def touch_creation_counter(self):
+        bases = type(self).__mro__
+        root = bases[bases.index(OrderedBase) - 1]
+        if not hasattr(root, self.CREATION_COUNTER_FIELD):
+            setattr(root, self.CREATION_COUNTER_FIELD, 0)
+        next_counter = getattr(root, self.CREATION_COUNTER_FIELD)
+        setattr(self, self.CREATION_COUNTER_FIELD, next_counter)
+        setattr(root, self.CREATION_COUNTER_FIELD, next_counter + 1)
 
 
 def sort_ordered_objects(items, getter=lambda x: x):

--- a/tests/test_using.py
+++ b/tests/test_using.py
@@ -1331,6 +1331,21 @@ class TraitTestCase(unittest.TestCase):
             dict(one=None, two=None, three=None, four=None, five=None),
         )
 
+    def test_traits_override_params(self):
+        """Override a Params value in a trait"""
+        class TestObjectFactory(factory.Factory):
+            class Meta:
+                model = TestObject
+
+            one = factory.LazyAttribute(lambda o: o.zero + 1)
+
+            class Params:
+                zero = 0
+                plus_one = factory.Trait(zero=1)
+
+        obj = TestObjectFactory(plus_one=True)
+        self.assertEqual(obj.one, 2)
+
     def test_traits_override(self):
         """Override a trait in a subclass."""
         class TestObjectFactory(factory.Factory):


### PR DESCRIPTION
When a factory defines a Params attribute and a Trait in which this attribute is overriden, the override of the trait is ignored.


```
class TruckFactory(factory.Factory):
    weight = factory.LazyAttribute()

```

The `Trait` is created when the Factory class is built and the `SimpleParameter` are built later at `contribute_to_class`, and they get a higher creation counter 
To fix, I update the creation counter so that the `Trait` gets ordered after the `SimpleParameter`