### PR TITLE
Synchronize faker random seed with factory_boy on get_random_state

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -2101,6 +2101,7 @@ of :class:`random.Random`, which can be managed through the :mod:`factory.random
 .. method:: get_random_state()
 
     Call :meth:`get_random_state` to retrieve the random generator's current
+    state. This method synchronizes both Faker’s and `factory_boy`’s random
     state.
     The returned object is implementation-specific.
 

--- a/factory/random.py
+++ b/factory/random.py
@@ -10,7 +10,10 @@ randgen.state_set = False
 
 def get_random_state():
     """Retrieve the state of factory.fuzzy's random generator."""
-    return randgen.getstate()
+    state = randgen.getstate()
+    # Returned state must represent both Faker and factory_boy.
+    faker.generator.random.setstate(state)
+    return state
 
 
 def set_random_state(state):


### PR DESCRIPTION
`random.set_random_state` seeds both faker and factory_boy random generators. It would make sense that the state returned by `get_random_state()` represents both faker and factory_boy random state.