### PR TITLE
Updated chained signal test case to explicit asserts

### DIFF
--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -932,7 +932,7 @@ class PreventSignalsTestCase(django_test.TestCase):
 class PreventChainedSignalsTestCase(django_test.TestCase):
 
     def setUp(self):
-        self.post_save_mock = mock.MagicMock(side_effect=Exception('BOOM!'))
+        self.post_save_mock = mock.Mock(side_effect=Exception('BOOM!'))
         signals.post_save.connect(self.post_save_mock, models.PointedModel)
 
     def tearDown(self):


### PR DESCRIPTION
#### What's this do?
Adding in explicit asserts to signal chaining tests. Also, refactored out the decorated factory to an inner class.

Feedback from previous PR:
```
LGTM. Tests can be improved by explicitly asserting that the signal is not run, to distinguish a failure from an error.
```

Tagging @federicobond 

#### Why are we doing this? 
Incorporating testing feedback from previous PR: https://github.com/FactoryBoy/factory_boy/pull/592

#### Anything the reviewer(s) should know to review effectively?
I actually revisited the `_get_or_create` method on `DjangoModelFactory` and it's only ever called in the context of `_create` which is currently being protected by the fix applied in: https://github.com/FactoryBoy/factory_boy/pull/592

So I left out wrapping that method as it would be redundant.

#### Any questions for the reviewers?
N/A

#### How should this be tested?
Current testing suite should be sufficient 