### PR TITLE
django_get_or_create: Limit get_or_create to specified fields

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ ChangeLog
 
     - Fix issue with SubFactory not preserving signal muting behaviour of the used factory, thanks `Patrick Stein <https://github.com/PFStein>`_.
     - Fix issue with overriding params in a Trait, thanks `Grégoire Rocher <https://github.com/cecedille1>`_.
+    - :issue:`598`: Limit ``get_or_create`` behavior to fields specified in ``django_get_or_create``.
 
 
 2.12.0 (2019-05-11)

--- a/tests/djapp/models.py
+++ b/tests/djapp/models.py
@@ -35,6 +35,7 @@ class MultifieldModel(models.Model):
 class MultifieldUniqueModel(models.Model):
     slug = models.SlugField(max_length=20, unique=True)
     text = models.CharField(max_length=20, unique=True)
+    title = models.CharField(max_length=20, unique=True)
 
 
 class AbstractBase(models.Model):

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -223,12 +223,14 @@ class DjangoGetOrCreateTests(django_test.TestCase):
         self.assertEqual(2, len(set(objs)))
         self.assertEqual(2, models.MultifieldModel.objects.count())
 
-    def test_multiple_get_or_create_fields_one_defined(self):
+
+class MultipleGetOrCreateFieldsTest(django_test.TestCase):
+    def test_one_defined(self):
         obj1 = WithMultipleGetOrCreateFieldsFactory()
         obj2 = WithMultipleGetOrCreateFieldsFactory(slug=obj1.slug)
         self.assertEqual(obj1, obj2)
 
-    def test_multiple_get_or_create_fields_both_defined(self):
+    def test_both_defined(self):
         obj1 = WithMultipleGetOrCreateFieldsFactory()
         self.assertRaises(
             ValueError,

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -237,6 +237,11 @@ class MultipleGetOrCreateFieldsTest(django_test.TestCase):
             lambda: WithMultipleGetOrCreateFieldsFactory(
                 slug=obj1.slug, text="alt"))
 
+    def test_unique_field_not_in_get_or_create(self):
+        WithMultipleGetOrCreateFieldsFactory(title="Title")
+        with self.assertRaises(django.db.IntegrityError):
+            WithMultipleGetOrCreateFieldsFactory(title="Title")
+
 
 class DjangoPkForceTestCase(django_test.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #598
Refs #239 