### PR TITLE
Specify ORM support policy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -347,6 +347,13 @@ This will yield messages similar to those (artificial indentation):
       LazyStub: Computed values, got tests.test_using.TestModel2Factory(two=<tests.test_using.TestModel object at 0x1e15410>)
     BaseFactory: Generating tests.test_using.TestModel2Factory(two=<tests.test_using.TestModel object at 0x1e15410>)
 
+Support Policy
+--------------
+
+- **Django**'s [supported
+  versions](https://www.djangoproject.com/download/#supported-versions).
+- **SQLAlchemy**: [latest version on PyPI](https://pypi.org/project/SQLAlchemy/).
+- **mongoengine**: [latest version on PyPI](https://pypi.org/project/mongoengine/).
 
 Contributing
 ------------

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,12 @@
 minversion = 1.9
 envlist =
     lint
-    py{27,34,35,36,37}-django111-alchemy13-mongoengine017,
-    py{34,35,36,37}-django20-alchemy13-mongoengine017,
-    py{35,36,37}-django21-alchemy13-mongoengine017,
-    py{35,36,37}-django22-alchemy13-mongoengine017,
-    pypy-django{111}-alchemy13-mongoengine017,
-    pypy3-django{111,20,21,22}-alchemy13-mongoengine017,
+    py{27,34,35,36,37}-django111-alchemy-mongoengine,
+    py{34,35,36,37}-django20-alchemy-mongoengine,
+    py{35,36,37}-django21-alchemy-mongoengine,
+    py{35,36,37}-django22-alchemy-mongoengine,
+    pypy-django{111}-alchemy-mongoengine,
+    pypy3-django{111,20,21,22}-alchemy-mongoengine,
     docs
     examples
     linkcheck
@@ -22,8 +22,8 @@ deps =
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
     django{111,20,21,22}: Pillow
-    alchemy13: SQLAlchemy>=1.3,<1.4
-    mongoengine017: mongoengine>=0.17,<0.18
+    alchemy: SQLAlchemy
+    mongoengine: mongoengine
 
 whitelist_externals = make
 commands = make test


### PR DESCRIPTION
Tests are only run against the supported versions of `Django`, latest `mongoengine` and latest `SQLAlchemy`. Explicit support policy and adjust Travis to follow it.