### PR TITLE
Turn warnings into errors during tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,18 @@ testall:
 
 # DOC: Run tests for the currently installed version
 test:
-	python -Wdefault -m unittest discover
+	# imp warning is a PendingDeprecationWarning for Python 3.4 and Python 3.5
+	# and a DeprecationWarning for later versions.
+	# Change PendingDeprecationWarning to distutils modules when dropping
+	# support for Python 3.4.
+	python \
+		-b \
+		-Werror \
+		-Wdefault:"'U' mode is deprecated":DeprecationWarning:site: \
+		-Wdefault:"the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses":DeprecationWarning:distutils: \
+		-Wdefault:"the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses":PendingDeprecationWarning:: \
+		-Wdefault:"Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working":DeprecationWarning:: \
+		-m unittest discover
 
 # DOC: Test the examples
 example-test:

--- a/factory/django.py
+++ b/factory/django.py
@@ -217,8 +217,8 @@ class FileField(declarations.ParameteredAttribute):
 
         if params.get('from_path'):
             path = params['from_path']
-            f = open(path, 'rb')
-            content = django_files.File(f, name=path)
+            with open(path, 'rb') as f:
+                content = django_files.base.ContentFile(f.read())
 
         elif params.get('from_file'):
             f = params['from_file']
@@ -267,9 +267,9 @@ class ImageField(FileField):
         color = params.get('color', 'blue')
         image_format = params.get('format', 'JPEG')
 
-        thumb = Image.new('RGB', (width, height), color)
         thumb_io = io.BytesIO()
-        thumb.save(thumb_io, format=image_format)
+        with Image.new('RGB', (width, height), color) as thumb:
+            thumb.save(thumb_io, format=image_format)
         return thumb_io.getvalue()
 
 

--- a/tests/test_alchemy.py
+++ b/tests/test_alchemy.py
@@ -128,6 +128,9 @@ class SQLAlchemySessionPersistenceTestCase(unittest.TestCase):
 
     def test_force_flush_deprecation(self):
         with warnings.catch_warnings(record=True) as warning_list:
+            # Do not turn expected warning into an error.
+            warnings.filterwarnings("default", category=DeprecationWarning, module=r"tests\.test_alchemy")
+
             class OutdatedPersistenceFactory(StandardFactory):
                 class Meta:
                     force_flush = True

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -684,8 +684,8 @@ class DjangoImageFieldTestCase(django_test.TestCase):
         self.assertEqual(13, o.animage.height)
         self.assertEqual('django/example.jpg', o.animage.name)
 
-        i = Image.open(os.path.join(settings.MEDIA_ROOT, o.animage.name))
-        colors = i.getcolors()
+        with Image.open(os.path.join(settings.MEDIA_ROOT, o.animage.name)) as i:
+            colors = i.getcolors()
         # 169 pixels with rgb(254, 0, 0)
         self.assertEqual([(169, (254, 0, 0))], colors)
         self.assertEqual('JPEG', i.format)
@@ -699,8 +699,8 @@ class DjangoImageFieldTestCase(django_test.TestCase):
         self.assertEqual(13, o.animage.height)
         self.assertEqual('django/example.jpg', o.animage.name)
 
-        i = Image.open(os.path.join(settings.MEDIA_ROOT, o.animage.name))
-        colors = i.convert('RGB').getcolors()
+        with Image.open(os.path.join(settings.MEDIA_ROOT, o.animage.name)) as i:
+            colors = i.convert('RGB').getcolors()
         # 169 pixels with rgb(0, 0, 255)
         self.assertEqual([(169, (0, 0, 255))], colors)
         self.assertEqual('GIF', i.format)
@@ -775,9 +775,10 @@ class DjangoImageFieldTestCase(django_test.TestCase):
         o1 = WithImageFactory.build(animage__from_path=testdata.TESTIMAGE_PATH)
         o1.save()
 
-        o2 = WithImageFactory.build(animage__from_file=o1.animage)
-        self.assertIsNone(o2.pk)
-        o2.save()
+        with o1.animage as f:
+            o2 = WithImageFactory.build(animage__from_file=f)
+            self.assertIsNone(o2.pk)
+            o2.save()
 
         with o2.animage as f:
             # Image file for a 42x42 green jpeg: 301 bytes long.

--- a/tests/test_fuzzy.py
+++ b/tests/test_fuzzy.py
@@ -606,6 +606,8 @@ class FuzzyRandomTestCase(unittest.TestCase):
 
     def test_seeding_warning(self):
         with warnings.catch_warnings(record=True) as w:
+            # Do not turn expected warning into an error.
+            warnings.filterwarnings("default", category=UserWarning, module=r"tests\.test_fuzzy")
             fuzz = fuzzy.FuzzyDate(datetime.date(2013, 1, 1))
             utils.evaluate_declaration(fuzz)
             self.assertEqual(1, len(w))


### PR DESCRIPTION
Deprecation warnings about importing ABCs from the 'collections' module instead of 'collections.abc' are globally ignored. AFAICT there’s no way to ignore them only for external dependencies. They’ll turn into errors from Python 3.8 anyway.

Fixes #365