### PR TITLE
Re-raise IntegrityError when django_get_or_create fails

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ ChangeLog
     - Fix issue with SubFactory not preserving signal muting behaviour of the used factory, thanks `Patrick Stein <https://github.com/PFStein>`_.
     - Fix issue with overriding params in a Trait, thanks `Grégoire Rocher <https://github.com/cecedille1>`_.
     - :issue:`598`: Limit ``get_or_create`` behavior to fields specified in ``django_get_or_create``.
+    - :issue:`606`: Re-raise :class:`~django.db.IntegrityError` when `django_get_or_create` with multiple fields fails to lookup model using user provided keyword arguments.
 
 *Removed:*
     - Drop support for Python 3.4. This version [is not maintained anymore](https://www.python.org/downloads/release/python-3410/).

--- a/factory/django.py
+++ b/factory/django.py
@@ -169,12 +169,9 @@ class DjangoModelFactory(base.Factory):
                 try:
                     instance = manager.get(**get_or_create_params)
                 except manager.model.DoesNotExist:
-                    raise ValueError(
-                        "django_get_or_create - Unable to create a new object "
-                        "due an IntegrityError raised based on "
-                        "your model's uniqueness constraints. "
-                        "DoesNotExist: Unable to find an existing object based on "
-                        "the fields specified in your factory instance.")
+                    # Original params are not a valid lookup and triggered a create(),
+                    # that resulted in an IntegrityError. Follow Django’s behavior.
+                    raise e
             else:
                 raise e
 

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -233,7 +233,7 @@ class MultipleGetOrCreateFieldsTest(django_test.TestCase):
 
     def test_both_defined(self):
         obj1 = WithMultipleGetOrCreateFieldsFactory()
-        with self.assertRaises(ValueError):
+        with self.assertRaises(django.db.IntegrityError):
             WithMultipleGetOrCreateFieldsFactory(slug=obj1.slug, text="alt")
 
     def test_unique_field_not_in_get_or_create(self):


### PR DESCRIPTION
When:
* several fields are specified in `django_get_or_create`, and
* user specifies a subset of kwargs, and
* other kwargs listed in `django_get_or_create` have values generated by the factory,

a `get_or_create` lookup may trigger an `IntegrityError`. Indeed, a generated value that was not part of the original lookup is passed to `get_or_create()`, causing a failed `get()` and leading to a `create()` with more than user specified kwargs and triggering an `IntegrityError`.

The `IntegrityError` is handled by factory_boy, and the model is looked up based on user specified kwargs. When the lookup fails, factory_boy raised a `ValueError`. Re-raise the original `IntegrityError` instead to align behavior with Django.

Fixes #606
Refs #345