### PR TITLE
Drop if __name__ == '__main__' from tests

### DIFF
--- a/examples/flask_alchemy/runtests.sh
+++ b/examples/flask_alchemy/runtests.sh
@@ -2,5 +2,5 @@
 
 cd $(dirname $0)
 for f in test_*.py; do
-    python "$f";
+    python -m unittest discover
 done

--- a/examples/flask_alchemy/test_demoapp.py
+++ b/examples/flask_alchemy/test_demoapp.py
@@ -30,6 +30,3 @@ class DemoAppTestCase(unittest.TestCase):
         self.assertIsNotNone(userlog.user.id)
         self.assertEqual(1, len(demoapp.User.query.all()))
         self.assertEqual(1, len(demoapp.UserLog.query.all()))
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/alter_time.py
+++ b/tests/alter_time.py
@@ -109,7 +109,3 @@ def main():  # pragma: no cover
     print("- today                     ->", datetime.date.today())
     print("- isinstance(now, date)     ->", isinstance(datetime.date.today(), datetime.date))
     print("- isinstance(target, date)  ->", isinstance(target_date, datetime.date))
-
-
-if __name__ == '__main__':  # pragma: no cover
-    main()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -542,7 +542,3 @@ class PostGenerationParsingTestCase(unittest.TestCase):
 
         self.assertIn('foo', TestObjectFactory._meta.post_declarations.as_dict())
         self.assertIn('foo__bar', TestObjectFactory._meta.post_declarations.as_dict())
-
-
-if __name__ == '__main__':  # pragma: no cover
-    unittest.main()

--- a/tests/test_declarations.py
+++ b/tests/test_declarations.py
@@ -304,7 +304,3 @@ class PostGenerationOrdering(unittest.TestCase):
         # Test generation happens in desired order
         Ordered()
         self.assertEqual(postgen_results, ['a1', 'zz', 'aa'])
-
-
-if __name__ == '__main__':  # pragma: no cover
-    unittest.main()

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -997,7 +997,3 @@ class DjangoCustomManagerTestCase(django_test.TestCase):
         # Our CustomManager will remove the 'arg=' argument,
         # invalid for the actual model.
         ObjFactory.create(arg='invalid')
-
-
-if __name__ == '__main__':  # pragma: no cover
-    unittest.main()

--- a/tests/test_using.py
+++ b/tests/test_using.py
@@ -2967,7 +2967,3 @@ class ListTestCase(unittest.TestCase):
                 1,
             ],
         ], o.two)
-
-
-if __name__ == '__main__':  # pragma: no cover
-    unittest.main()


### PR DESCRIPTION
Tests are using unittest autodiscover feature, making these entrypoints useless and confusing.