### PR TITLE
Introduce factory.declaration.Transformer 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,11 +3,35 @@ ChangeLog
 
 .. Note for v4.x: don't forget to check "Deprecated" sections for removal.
 
-3.2.1 (unreleased)
+3.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+*New:*
 
+    - :issue:`366`: Add :class:`factory.django.Password` to generate Django :class:`~django.contrib.auth.models.User`
+      passwords.
+
+*Deprecated:*
+
+    - :class:`~factory.django.DjangoModelFactory` will stop issuing a second call to
+      :meth:`~django.db.models.Model.save` on the created instance when :ref:`post-generation-hooks` return a value.
+
+      To help with the transition, :class:`factory.django.DjangoModelFactory._after_postgeneration` raises a
+      :class:`DeprecationWarning` when calling :meth:`~django.db.models.Model.save`. Inspect your
+      :class:`~factory.django.DjangoModelFactory` subclasses:
+
+      - If the :meth:`~django.db.models.Model.save` call is not needed after :class:`~factory.PostGeneration`, set
+        :attr:`factory.django.DjangoOptions.skip_postgeneration_save` to ``True`` in the factory meta.
+
+      - Otherwise, the instance has been modified by :class:`~factory.PostGeneration` hooks and needs to be
+        :meth:`~django.db.models.Model.save`\ d. Either:
+
+          - call :meth:`django.db.models.Model.save` in the :class:`~factory.PostGeneration` hook that modifies the
+            instance, or
+          - override :class:`~factory.django.DjangoModelFactory._after_postgeneration` to
+            :meth:`~django.db.models.Model.save` the instance.
+
+*Removed:*
 
 3.2.0 (2020-12-28)
 ------------------

--- a/docs/orms.rst
+++ b/docs/orms.rst
@@ -109,9 +109,46 @@ All factories for a Django :class:`~django.db.models.Model` should use the
                 >>> john.email                            # The email value was not updated
                 "john@example.com"
 
+    .. attribute:: skip_postgeneration_save
+
+        Transitional option to prevent
+        :meth:`~factory.django.DjangoModelFactory._after_postgeneration` from
+        issuing a duplicate call to :meth:`~django.db.models.Model.save` on the
+        created instance when :class:`factory.PostGeneration` hooks return a
+        value.
+
 
 Extra fields
 """"""""""""
+
+.. class:: Password
+
+    Applies :func:`~django.contrib.auth.hashers.make_password` to the
+    clear-text argument before to generate the object.
+
+    .. method:: __init__(self, password)
+
+        :param str password: Default password.
+
+    .. code-block:: python
+
+        class UserFactory(factory.django.DjangoModelFactory):
+            class Meta:
+                model = models.User
+
+            password = factory.django.Password('pw')
+
+    .. code-block:: pycon
+
+        >>> from django.contrib.auth.hashers import check_password
+        >>> # Create user with the default password from the factory.
+        >>> user = UserFactory.create()
+        >>> check_password('pw', user.password)
+        True
+        >>> # Override user password at call time.
+        >>> other_user = UserFactory.create(password='other_pw')
+        >>> check_password('other_pw', other_user.password)
+        True
 
 
 .. class:: FileField

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -904,6 +904,36 @@ return value of the method:
     'joel@example.com'
 
 
+Transformer
+"""""""""""
+
+.. class:: Transformer(transform, value)
+
+A :class:`Transformer` applies a ``transform`` function to the provided value
+before to set the transformed value on the generated object.
+
+It expects two arguments:
+
+- ``transform``: function taking the value as parameter and returning the
+  transformed value,
+- ``value``: the default value.
+
+.. code-block:: python
+
+   class UpperFactory(Factory):
+       name = Transformer(lambda x: x.upper(), "Joe")
+
+       class Meta:
+           model = Upper
+
+.. code-block:: pycon
+
+   >>> UpperFactory().name
+   'JOE'
+   >>> UpperFactory(name="John").name
+   'JOHN'
+
+
 Sequence
 """"""""
 
@@ -1592,6 +1622,7 @@ apply the effects of one or the other declaration:
           defined in the :attr:`~Factory.Params` section of your factory to
           handle the computation.
 
+.. _post-generation-hooks:
 
 Post-generation hooks
 """""""""""""""""""""

--- a/factory/__init__.py
+++ b/factory/__init__.py
@@ -26,6 +26,7 @@ from .declarations import (
     Sequence,
     SubFactory,
     Trait,
+    Transformer,
 )
 from .enums import BUILD_STRATEGY, CREATE_STRATEGY, STUB_STRATEGY
 from .errors import FactoryError

--- a/factory/builder.py
+++ b/factory/builder.py
@@ -2,7 +2,7 @@
 
 import collections
 
-from . import enums, errors, utils
+from . import declarations, enums, errors, utils
 
 DeclarationWithContext = collections.namedtuple(
     'DeclarationWithContext',
@@ -156,6 +156,10 @@ def parse_declarations(decls, base_pre=None, base_post=None):
             # Set it as `key__`
             magic_key = post_declarations.join(k, '')
             extra_post[magic_key] = v
+        elif k in pre_declarations and isinstance(
+            pre_declarations[k].declaration, declarations.Transformer
+        ):
+            extra_maybenonpost[k] = pre_declarations[k].declaration.function(v)
         else:
             extra_maybenonpost[k] = v
 

--- a/factory/declarations.py
+++ b/factory/declarations.py
@@ -100,6 +100,22 @@ class LazyAttribute(BaseDeclaration):
         return self.function(instance)
 
 
+class Transformer(LazyFunction):
+    """Transform value using given function.
+
+    Attributes:
+        transform (function): returns the transformed value.
+        value: passed as the first argument to the transform function.
+    """
+
+    def __init__(self, transform, value, *args, **kwargs):
+        super().__init__(transform, *args, **kwargs)
+        self.value = value
+
+    def evaluate(self, instance, step, extra):
+        return self.function(self.value)
+
+
 class _UNSPECIFIED:
     pass
 

--- a/tests/djapp/models.py
+++ b/tests/djapp/models.py
@@ -75,6 +75,10 @@ class WithDefaultValue(models.Model):
     foo = models.CharField(max_length=20, default='')
 
 
+class WithPassword(models.Model):
+    pw = models.CharField(max_length=128)
+
+
 WITHFILE_UPLOAD_TO = 'django'
 WITHFILE_UPLOAD_DIR = os.path.join(settings.MEDIA_ROOT, WITHFILE_UPLOAD_TO)
 

--- a/tests/test_declarations.py
+++ b/tests/test_declarations.py
@@ -132,6 +132,12 @@ class IteratorTestCase(unittest.TestCase):
         self.assertEqual(3, utils.evaluate_declaration(it, force_sequence=3))
 
 
+class TransformerTestCase(unittest.TestCase):
+    def test_transform(self):
+        t = declarations.Transformer(lambda x: x.upper(), 'foo')
+        self.assertEqual("FOO", utils.evaluate_declaration(t))
+
+
 class PostGenerationDeclarationTestCase(unittest.TestCase):
     def test_post_generation(self):
         call_params = []

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1,0 +1,46 @@
+# Copyright: See the LICENSE file.
+
+from unittest import TestCase
+
+from factory import Factory, Transformer
+
+
+class TransformCounter:
+    calls_count = 0
+
+    @classmethod
+    def __call__(cls, x):
+        cls.calls_count += 1
+        return x.upper()
+
+    @classmethod
+    def reset(cls):
+        cls.calls_count = 0
+
+
+transform = TransformCounter()
+
+
+class Upper:
+    def __init__(self, name):
+        self.name = name
+
+
+class UpperFactory(Factory):
+    name = Transformer(transform, "value")
+
+    class Meta:
+        model = Upper
+
+
+class TransformerTest(TestCase):
+    def setUp(self):
+        transform.reset()
+
+    def test_transform_count(self):
+        self.assertEqual("VALUE", UpperFactory().name)
+        self.assertEqual(transform.calls_count, 1)
+
+    def test_transform_kwarg(self):
+        self.assertEqual("TEST", UpperFactory(name="test").name)
+        self.assertEqual(transform.calls_count, 1)


### PR DESCRIPTION
Transforms a value using provided `transform` function. Values coming from the declaration and values overridden through keywords arguments are transformed before the generated object attribute is set.

Removes the need to save objects with a post generation hook twice to the database.

Facilitates overriding Django passwords when instantiating the factory.

Fixes #316
Fixes #366