### PR TITLE
Add a note about using factory.Factory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,6 +134,10 @@ The class of the object must be defined in the ``model`` field of a ``class Meta
         last_name = 'User'
         admin = True
 
+.. note:: Do note, that ``factory.Factory`` is to be used for generating plain
+          Python objects. For ORM models, see corresponding part of the
+          documentation.
+
 
 Using factories
 """""""""""""""


### PR DESCRIPTION
I'd also like to add a link that points to the current version of the documentation on Read The Docs. But that is probably impossible. Should I add a link to https://factoryboy.readthedocs.io/en/latest/orms.html?

Resolves #587.