### PR TITLE
Allow configuring the colour palette of ImageField

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -40,6 +40,7 @@ The project has received contributions from (in alphabetical order):
 * François Freitag <mail@franek.fr>
 * George Hickman <george@ghickman.co.uk>
 * Hervé Cauwelier <herve.cauwelier@polyconseil.fr>
+* Hugo Osvaldo Barrera <hugo@barrera.io>
 * Ilya Baryshev <baryshev@gmail.com>
 * Ilya Pirogov <ilja.pirogov@gmail.com>
 * Ionuț Arțăriși <ionut@artarisi.eu>

--- a/docs/orms.rst
+++ b/docs/orms.rst
@@ -144,6 +144,7 @@ Extra fields
         :param int height: The height of the generated image (default: ``100``)
         :param str color: The color of the generated image (default: ``'green'``)
         :param str format: The image format (as supported by PIL) (default: ``'JPEG'``)
+        :param str palette: The image palette (as supported by PIL) (default: ``'RGB'``)
 
 .. note:: If the value ``None`` was passed for the :class:`FileField` field, this will
           disable field generation:

--- a/factory/django.py
+++ b/factory/django.py
@@ -268,9 +268,10 @@ class ImageField(FileField):
         height = params.get('height', width)
         color = params.get('color', 'blue')
         image_format = params.get('format', 'JPEG')
+        image_palette = params.get('palette', 'RGB')
 
         thumb_io = io.BytesIO()
-        with Image.new('RGB', (width, height), color) as thumb:
+        with Image.new(image_palette, (width, height), color) as thumb:
             thumb.save(thumb_io, format=image_format)
         return thumb_io.getvalue()
 

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -727,6 +727,16 @@ class DjangoImageFieldTestCase(django_test.TestCase):
         self.assertEqual([(169, (254, 0, 0))], colors)
         self.assertEqual('JPEG', i.format)
 
+    def test_rgba_image(self):
+        o = WithImageFactory.create(
+            animage__palette='RGBA',
+            animage__format='PNG',
+        )
+        self.assertIsNotNone(o.pk)
+
+        with Image.open(os.path.join(settings.MEDIA_ROOT, o.animage.name)) as i:
+            self.assertEqual('RGBA', i.mode)
+
     def test_gif(self):
         o = WithImageFactory.build(animage__width=13, animage__color='blue', animage__format='GIF')
         self.assertIsNone(o.pk)


### PR DESCRIPTION
This allows, for example, to create configure an `ImageField` to be populated with `RBGA` or `CMYK` images.

The default behaviour remains the same as it is now.