### PR TITLE
Add SQLAlchemy get_or_create support

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ ChangeLog
     - Report misconfiguration when a :py:class:`~factory.Factory` is used as the :py:attr:`~factory.Factory.model` for another :py:class:`~factory.Factory`.
     - Allow configuring the color palette of :py:class:`~factory.django.ImageField`.
     - :py:meth:`get_random_state()` now represents the state of Faker and ``factory_boy`` fuzzy attributes.
+    - Add SQLAlchemy ``get_or_create`` support
 
 *Bugfix:*
 

--- a/docs/orms.rst
+++ b/docs/orms.rst
@@ -325,6 +325,43 @@ To work, this class needs an `SQLAlchemy`_ session object affected to the :attr:
 
         The default value is ``None``.
 
+    .. attribute:: sqlalchemy_get_or_create
+
+        .. versionadded:: 3.0.0
+
+        Fields whose name are passed in this list will be used to perform a
+        :meth:`Model.query.one_or_none() <sqlalchemy.orm.query.Query.one_or_none>`
+        or the usual :meth:`Session.add() <sqlalchemy.orm.session.Session.add>`:
+
+        .. code-block:: python
+
+            class UserFactory(factory.alchemy.SQLAlchemyModelFactory):
+                class Meta:
+                    model = User
+                    sqlalchemy_session = session
+                    sqlalchemy_get_or_create = ('username',)
+
+                username = 'john'
+
+        .. code-block:: pycon
+
+            >>> User.query.all()
+            []
+            >>> UserFactory()                   # Creates a new user
+            <User: john>
+            >>> User.query.all()
+            [<User: john>]
+
+            >>> UserFactory()                   # Fetches the existing user
+            <User: john>
+            >>> User.query.all()                # No new user!
+            [<User: john>]
+
+            >>> UserFactory(username='jack')    # Creates another user
+            <User: jack>
+            >>> User.query.all()
+            [<User: john>, <User: jack>]
+
 
 A (very) simple example:
 

--- a/factory/alchemy.py
+++ b/factory/alchemy.py
@@ -1,6 +1,9 @@
 # Copyright: See the LICENSE file.
 
-from . import base
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm.exc import NoResultFound
+
+from . import base, errors
 
 SESSION_PERSISTENCE_COMMIT = 'commit'
 SESSION_PERSISTENCE_FLUSH = 'flush'
@@ -21,6 +24,7 @@ class SQLAlchemyOptions(base.FactoryOptions):
 
     def _build_default_options(self):
         return super()._build_default_options() + [
+            base.OptionDefault('sqlalchemy_get_or_create', (), inherit=True),
             base.OptionDefault('sqlalchemy_session', None, inherit=True),
             base.OptionDefault(
                 'sqlalchemy_session_persistence',
@@ -40,14 +44,65 @@ class SQLAlchemyModelFactory(base.Factory):
         abstract = True
 
     @classmethod
+    def _generate(cls, strategy, params):
+        # Original params are used in _get_or_create if it cannot build an
+        # object initially due to an IntegrityError being raised
+        cls._original_params = params
+        return super(SQLAlchemyModelFactory, cls)._generate(strategy, params)
+
+    @classmethod
+    def _get_or_create(cls, model_class, session, *args, **kwargs):
+        key_fields = {}
+        for field in cls._meta.sqlalchemy_get_or_create:
+            if field not in kwargs:
+                raise errors.FactoryError(
+                    "sqlalchemy_get_or_create - "
+                    "Unable to find initialization value for '%s' in factory %s" %
+                    (field, cls.__name__))
+            key_fields[field] = kwargs.pop(field)
+
+        obj = session.query(model_class).filter_by(
+            *args, **key_fields).one_or_none()
+
+        if not obj:
+            try:
+                obj = cls._save(model_class, session, *args, **key_fields, **kwargs)
+            except IntegrityError as e:
+                session.rollback()
+                get_or_create_params = {
+                    lookup: value
+                    for lookup, value in cls._original_params.items()
+                    if lookup in cls._meta.sqlalchemy_get_or_create
+                }
+                if get_or_create_params:
+                    try:
+                        obj = session.query(model_class).filter_by(
+                            **get_or_create_params).one()
+                    except NoResultFound:
+                        # Original params are not a valid lookup and triggered a create(),
+                        # that resulted in an IntegrityError.
+                        raise e
+                else:
+                    raise e
+
+        return obj
+
+    @classmethod
     def _create(cls, model_class, *args, **kwargs):
         """Create an instance of the model, and save it to the database."""
         session = cls._meta.sqlalchemy_session
+
+        if session is None:
+            raise RuntimeError("No session provided.")
+        if cls._meta.sqlalchemy_get_or_create:
+            return cls._get_or_create(model_class, session, *args, **kwargs)
+        return cls._save(model_class, session, *args, **kwargs)
+
+    @classmethod
+    def _save(cls, model_class, session, *args, **kwargs):
         session_persistence = cls._meta.sqlalchemy_session_persistence
 
         obj = model_class(*args, **kwargs)
-        if session is None:
-            raise RuntimeError("No session provided.")
         session.add(obj)
         if session_persistence == SESSION_PERSISTENCE_FLUSH:
             session.flush()

--- a/tests/alchemyapp/models.py
+++ b/tests/alchemyapp/models.py
@@ -20,6 +20,23 @@ class StandardModel(Base):
     foo = Column(Unicode(20))
 
 
+class MultiFieldModel(Base):
+    __tablename__ = 'MultiFieldModelTable'
+
+    id = Column(Integer(), primary_key=True)
+    foo = Column(Unicode(20))
+    slug = Column(Unicode(20), unique=True)
+
+
+class MultifieldUniqueModel(Base):
+    __tablename__ = 'MultiFieldUniqueModelTable'
+
+    id = Column(Integer(), primary_key=True)
+    slug = Column(Unicode(20), unique=True)
+    text = Column(Unicode(20), unique=True)
+    title = Column(Unicode(20), unique=True)
+
+
 class NonIntegerPk(Base):
     __tablename__ = 'NonIntegerPk'
 


### PR DESCRIPTION
This is a naive implementation purely translated from django  `get_or_create` functionality as requested in [#99](https://github.com/FactoryBoy/factory_boy/issues/99).