### PR TITLE
Remove unused tag-format from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,9 +8,6 @@ license_file = LICENSE
 ; semver-style versions
 version-levels = 3
 
-; tags: vX.Y.Z; the double-percent is a guard against ConfigParser.
-#tag-format = v%%(version)s
-
 ; Version flag location (we use __version__)
 python-file-with-version = factory/__init__.py
 


### PR DESCRIPTION
Last release with the `v` prefix in the tag was done on Jul 30, 2017.