### PR TITLE
Remove warning exclusion for Python3.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,16 +52,14 @@ testall:
 
 # DOC: Run tests for the currently installed version
 test:
-	# imp warning is a PendingDeprecationWarning for Python 3.4 and Python 3.5
-	# and a DeprecationWarning for later versions.
-	# Change PendingDeprecationWarning to distutils modules when dropping
-	# support for Python 3.4.
+	# imp warning is a PendingDeprecationWarning for Python 3.5 and a
+	# DeprecationWarning for later versions.
 	python \
 		-b \
 		-Werror \
 		-Wdefault:"'U' mode is deprecated":DeprecationWarning:site: \
 		-Wdefault:"the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses":DeprecationWarning:distutils: \
-		-Wdefault:"the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses":PendingDeprecationWarning:: \
+		-Wdefault:"the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses":PendingDeprecationWarning:distutils: \
 		-Wdefault:"Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working":DeprecationWarning:: \
 		-m unittest discover
 


### PR DESCRIPTION
Python 3.4 support was dropped in 55fbaa71fa85ea65313a07866e6563e4dffe28c4.