### PR TITLE
Drop dist: xenial from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: xenial
 language: python
 cache: pip
 


### PR DESCRIPTION
xenial is now the default.