### PR TITLE
Remove requirements_test.txt

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,11 +1,12 @@
 -e .
 -r requirements_docs.txt
--r requirements_test.txt
 -r examples/requirements.txt
 
 coverage
 Django
+flake8
 isort
+mock;python_version<"3"
 Pillow
 SQLAlchemy
 mongoengine

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,0 @@
-mock
-flake8

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ toxworkdir = {env:TOX_WORKDIR:.tox}
 
 [testenv]
 deps =
-    -rrequirements_test.txt
+    mock;python_version<"3"
     django111: Django>=1.11,<1.12
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
@@ -38,7 +38,6 @@ commands = make doc
 [testenv:examples]
 basepython = python3.7
 deps =
-    -rrequirements_test.txt
     -rexamples/requirements.txt
 
 whitelist_externals = make


### PR DESCRIPTION
Lint dependencies are managed by tox, flake8 was installed but not used.
Tests are managed by tox, declare test requirements in tox.ini.

Mock was added as a development dependency, to avoid disruption for Python 2.7 developers (if some remain :))