### PR TITLE
Simplify tests/compat.py a bit

### DIFF
--- a/tests/compat.py
+++ b/tests/compat.py
@@ -9,10 +9,7 @@ is_python2 = (sys.version_info[0] == 2)
 
 if is_python2:
     import StringIO as io
-else:
-    import io  # noqa: F401
-
-if sys.version_info[0:2] < (3, 3):
     import mock
 else:
+    import io  # noqa: F401
     from unittest import mock  # noqa: F401


### PR DESCRIPTION
Oldest support version of Python is 3.5, the alternative import path is only kept for Python 2.