### PR TITLE
Remove `known_third_party` option from isort config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,4 +19,3 @@ force_grid_wrap = 0
 use_parentheses = True
 line_length = 88
 known_first_party = factory
-known_third_party = django,faker,mongoengine


### PR DESCRIPTION
The list was incomplete. `isort` sorts these libraries correctly without this option.