### PR TITLE
Remove setuptools from setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,6 @@ setup(
     install_requires=[
         'Faker>=0.7.0',
     ],
-    setup_requires=[
-        'setuptools>=0.8',
-    ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Django",


### PR DESCRIPTION
The package is imported at the top of the module, so it is present on the machine. Version 0.8 was released on Jul 5, 2013. Can assume all machines installing factory_boy have setuptools available.