### PR TITLE
Remove `known_third_party` option from isort config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,5 +18,3 @@ include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True
 line_length = 88
-known_first_party = factory
-known_third_party = django,faker,mongoengine

--- a/tox.ini
+++ b/tox.ini
@@ -54,8 +54,7 @@ commands = make linkcheck
 
 [testenv:lint]
 deps =
-    flake8
-    isort
+    -rrequirements_dev.txt
     check_manifest
 skip_install = true
 


### PR DESCRIPTION
The list was incomplete. `isort` sorts these libraries correctly without this option when they are installed.