### PR TITLE
Restore factory.__version__ attribute

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,8 @@
 import os
 import sys
 
+import factory
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -59,21 +61,8 @@ copyright = u'2011-2015, Raphaël Barrois, Mark Sandstrom'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-root = os.path.abspath(os.path.dirname(__file__))
-def get_version(*module_dir_components):
-    import re
-    version_re = re.compile(r"^__version__ = ['\"](.*)['\"]$")
-    module_root = os.path.join(root, os.pardir, *module_dir_components)
-    module_init = os.path.join(module_root, '__init__.py')
-    with open(module_init, 'r') as f:
-        for line in f:
-            match = version_re.match(line[:-1])
-            if match:
-                return match.groups()[0]
-    return '0.1.0'
-
 # The full version, including alpha/beta/rc tags.
-release = get_version('factory')
+release = factory.__version__
 # The short X.Y version.
 version = '.'.join(release.split('.')[:2])
 

--- a/factory/__init__.py
+++ b/factory/__init__.py
@@ -55,6 +55,15 @@ from .helpers import (
 )
 
 __author__ = 'Raphaël Barrois <raphael.barrois+fboy@polytechnique.org>'
+try:
+    # Python 3.8+
+    from importlib.metadata import version
+
+    __version__ = version("factory_boy")
+except ImportError:
+    import pkg_resources
+
+    __version__ = pkg_resources.get_distribution("factory_boy").version
 
 
 MogoFactory = mogo.MogoFactory

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,2 +1,3 @@
+-e .
 Sphinx
 sphinx_rtd_theme


### PR DESCRIPTION
Allows third party libraries (such as django-factory_boy or pytest-factoryboy) to work around breaking changes in factory_boy.

Partially reverts 93bbd0317092c8e804d039ed60413f4b75fd7e77.