### PR TITLE
Remove end of life Django 2.1 from the test matrix

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,7 +19,7 @@ ChangeLog
 
 *Removed:*
     - Drop support for Python 3.4. This version [is not maintained anymore](https://www.python.org/downloads/release/python-3410/).
-    - Drop support for Django 2.0. This version [is not maintained anymore](https://www.djangoproject.com/download/#supported-versions).
+    - Drop support for Django 2.0 and 2.1. These versions [are not maintained anymore](https://www.djangoproject.com/download/#supported-versions).
 
 
 2.12.0 (2019-05-11)

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Framework :: Django
     Framework :: Django :: 1.11
-    Framework :: Django :: 2.1
     Framework :: Django :: 2.2
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,9 @@ minversion = 1.9
 envlist =
     lint
     py{27,35,36,37,38}-django111-alchemy-mongoengine,
-    py{35,36,37,38}-django21-alchemy-mongoengine,
     py{35,36,37,38}-django22-alchemy-mongoengine,
     pypy-django{111}-alchemy-mongoengine,
-    pypy3-django{111,21,22}-alchemy-mongoengine,
+    pypy3-django{111,22}-alchemy-mongoengine,
     docs
     examples
     linkcheck
@@ -17,9 +16,8 @@ toxworkdir = {env:TOX_WORKDIR:.tox}
 deps =
     mock;python_version<"3"
     django111: Django>=1.11,<1.12
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
-    django{111,21,22}: Pillow
+    django{111,22}: Pillow
     alchemy: SQLAlchemy
     mongoengine: mongoengine
 


### PR DESCRIPTION
Django 2.1 went EOL on December 2, 2019.

https://www.djangoproject.com/download/#supported-versions