### PR TITLE
Fixes #688: Describe Many-to-many for SQLAlchemy

### DIFF
--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -199,6 +199,9 @@ But when ``UserFactory.create(groups=(group1, group2, group3))`` is called,
 the ``groups`` declaration will add passed in groups to the set of groups for the
 user.
 
+For SQLAlchemy, ``list`` is for many-to-many relationship.
+Modify ``self.groups.add(group)`` to ``self.groups.append(group)`` from the above example,
+then create ``UserFactory.create(groups=[group1, group2, group3])``
 
 Many-to-many relation with a 'through'
 --------------------------------------


### PR DESCRIPTION
This change describes Many-to-many relationship example for SQLAlchemy.