### PR TITLE
Remove deprecated license_file from setup.cfg

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,6 +10,6 @@ mock;python_version<"3"
 Pillow
 SQLAlchemy
 mongoengine
-wheel
+wheel>=0.32.0
 tox
 zest.releaser[recommended]

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ maintainer_email = raphael.barrois+fboy@polytechnique.org
 url = https://github.com/FactoryBoy/factory_boy
 keywords = factory_boy, factory, fixtures
 license = MIT
-license_file = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable
     Framework :: Django


### PR DESCRIPTION
Starting with wheel 0.32.0 (2018-09-29), the "license_file" option is
deprecated.

https://wheel.readthedocs.io/en/stable/news.html

The wheel will continue to include LICENSE, it is now included
automatically:

https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file