### PR TITLE
Add trove classifier for CPython support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Software Development :: Testing
     Topic :: Software Development :: Libraries :: Python Modules


### PR DESCRIPTION
Serves in contrast to PyPy support. Both implementations are tested and
supported.