### PR TITLE
Remove fallback for deprecated, unsupported Pillow package "Image"

### DIFF
--- a/factory/django.py
+++ b/factory/django.py
@@ -259,10 +259,7 @@ class ImageField(FileField):
     def _make_data(self, params):
         # ImageField (both django's and factory_boy's) require PIL.
         # Try to import it along one of its known installation paths.
-        try:
-            from PIL import Image
-        except ImportError:
-            import Image
+        from PIL import Image
 
         width = params.get('width', 100)
         height = params.get('height', width)

--- a/tests/djapp/models.py
+++ b/tests/djapp/models.py
@@ -11,10 +11,7 @@ from django.db import models
 try:
     from PIL import Image
 except ImportError:
-    try:
-        import Image
-    except ImportError:
-        Image = None
+    Image = None
 
 
 class StandardModel(models.Model):

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -22,12 +22,7 @@ from .compat import mock
 try:
     from PIL import Image
 except ImportError:
-    # Try PIL alternate name
-    try:
-        import Image
-    except ImportError:
-        # OK, not installed
-        Image = None
+    Image = None
 
 # Setup Django before importing Django models.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tests.djapp.settings')


### PR DESCRIPTION
From https://pillow.readthedocs.io/en/stable/installation.html

> Pillow >= 1.0 no longer supports “import Image”. Please use “from PIL
> import Image” instead.