### PR TITLE
Install factory_boy in readthedocs build environment

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ graft docs
 graft examples
 graft tests
 
+exclude readthedocs.yml
 global-exclude *.py[cod] __pycache__ .*.sw[po]
 prune .github
 prune docs/_build

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,8 @@
+---
+version: 2
+python:
+  install:
+    - method: pip
+      package: .
+      extra_requirements:
+        - doc


### PR DESCRIPTION
3eb79173eee147ec5cf827d20b1a1caf5aec915e restored the `__version__`
attribute in the `factory` module, and transitioned the documentation to
read the version for it. However, `factory_boy` is missing from
readthedocs build environment. Attempts to read the `__version__`
resulted in:

```
ModuleNotFoundError: No module named 'factory'
```

Refs #676
Fixes #704 