### PR TITLE
Change m2m post_generation example to look like a staticmethod

### DIFF
--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -180,7 +180,7 @@ hook:
         name = "John Doe"
 
         @factory.post_generation
-        def groups(self, create, extracted, **kwargs):
+        def groups(obj, create, extracted, **kwargs):
             if not create:
                 # Simple build, do nothing.
                 return
@@ -188,7 +188,7 @@ hook:
             if extracted:
                 # A list of groups were passed in, use them
                 for group in extracted:
-                    self.groups.add(group)
+                    obj.groups.add(group)
 
 .. OHAI_VIM**
 


### PR DESCRIPTION
Hi, factory_boy maintainers! Long time user, first time contributor. 😁 Thanks for creating an amazing resource for the community.

Based on the [reference docs](https://factoryboy.readthedocs.io/en/latest/reference.html?highlight=post_generation#factory.post_generation), the `post_generation` decorator doesn't behave like an instance method on the factory. The first parameter is listed as `self` in the many-to-many recipe, but `self` is actually a model instance instead of a factory instance.

In the other areas where `post_generation` is referenced, the first parameter seems to be named `obj`. This documentation change updates the example to be consistent with other usage.