### PR TITLE
Simplify RelatedFactoryList documented example

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1755,14 +1755,11 @@ RelatedFactoryList
 
           .. code-block:: python
 
-              LIST_SIZES = [1, 2, 3, 4, 5]
-
               class FooFactory(factory.Factory):
                   class Meta:
                       model = Foo
                   # Generate a list of `factory` objects of random size, ranging from 1 -> 5
-                  bar = factory.RelatedFactoryList(BarFactory,
-                                                   size=lambda: LIST_SIZES[random.randint(0,5)])
+                  bar = factory.RelatedFactoryList(BarFactory, size=lambda: random.randint(1, 5))
                   # Each Foo object will have exactly 3 Bar objects generated for its foobar attribute.
                   foobar = factory.RelatedFactoryList(BarFactory, size=3)
 


### PR DESCRIPTION
The LIST_SIZE constant is not useful, randint already returns an
integer in the given range.

Additionally, there was an off-by one index as randint bounds are
inclusive, causing an IndexError when randint returned 5.

Thanks @loren-jiang for the report!

Closes #741.