### PR TITLE
Fix readthedocs build

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,6 +3,6 @@ version: 2
 python:
   install:
     - method: pip
-      package: .
+      path: .
       extra_requirements:
         - doc


### PR DESCRIPTION
The correct key to specify the package to pip install is `path`, not
`package`.
https://docs.readthedocs.io/en/stable/config-file/v2.html#packages