### PR TITLE
Remove requirements*.txt from MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include ChangeLog CODE_OF_CONDUCT.md CONTRIBUTING.rst CREDITS LICENSE README.rst
-include requirements*.txt
 include Makefile tox.ini .flake8
 
 graft factory


### PR DESCRIPTION
The requirements file duplicate the `setup.py` instruction since
6f37f9be2d2e1bc75340068911db18b2bbcbe722.