### PR TITLE
Upgrade to isort 5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ example-test:
 lint:
 	$(FLAKE8) --exclude $(PACKAGE)/__init__.py $(EXAMPLES_DIR) $(PACKAGE) $(SETUP_PY) $(TESTS_DIR)
 	$(FLAKE8) --ignore F401 $(PACKAGE)/__init__.py
-	$(ISORT) --recursive --check-only --diff $(EXAMPLES_DIR) $(PACKAGE) $(SETUP_PY) $(TESTS_DIR)
+	$(ISORT) --check-only --diff $(EXAMPLES_DIR) $(PACKAGE) $(SETUP_PY) $(TESTS_DIR)
 	check-manifest
 
 coverage:

--- a/examples/flask_alchemy/demoapp_factories.py
+++ b/examples/flask_alchemy/demoapp_factories.py
@@ -1,4 +1,5 @@
 import demoapp
+
 import factory.alchemy
 import factory.fuzzy
 


### PR DESCRIPTION
https://timothycrosley.github.io/isort/docs/major_releases/introducing_isort_5/

The `--recursive` option is now the default behavior.

Linting failed with error:

```
ERROR: /home/travis/build/FactoryBoy/factory_boy/examples/flask_alchemy/demoapp_factories.py Imports are incorrectly sorted and/or formatted.
--- /home/travis/build/FactoryBoy/factory_boy/examples/flask_alchemy/demoapp_factories.py:before	2020-07-31 07:14:11.953212
+++ /home/travis/build/FactoryBoy/factory_boy/examples/flask_alchemy/demoapp_factories.py:after	2020-07-31 07:14:42.688270
@@ -1,4 +1,5 @@
 import demoapp
+
 import factory.alchemy
 import factory.fuzzy
```