### PR TITLE
Simplify isort config using 'profile = black'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ dev =
     coverage
     Django
     flake8
-    isort
+    isort>=5.0.2
     Pillow
     SQLAlchemy
     mongoengine
@@ -69,8 +69,4 @@ ignore =
 max-line-length = 120
 
 [isort]
-multi_line_output = 3
-include_trailing_comma = True
-force_grid_wrap = 0
-use_parentheses = True
-line_length = 88
+profile = black


### PR DESCRIPTION
isort now has builtin support for black through its "profiles" feature.

https://timothycrosley.github.io/isort/docs/configuration/profiles/#black