### PR TITLE
Fix small README class inconsistency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -213,7 +213,7 @@ For this, factory_boy relies on the excellent `faker <https://faker.readthedocs.
 
 .. code-block:: pycon
 
-    >>> UserFactory()
+    >>> RandomUserFactory()
     <User: Lucy Murray>
 
 


### PR DESCRIPTION
The `README.rst` file includes a section called "_Realistic, random values_", where a `RandomUserFactory` class is defined as an example, but then a `UserFactory` is used instead to show the usage, instead of `RandomUserFactory`. This Pull Request fixes that small inconsistency.