### PR TITLE
Fix crash when 'locale' isn't specified

### DIFF
--- a/factory/faker.py
+++ b/factory/faker.py
@@ -43,7 +43,7 @@ class Faker(declarations.ParameteredDeclaration):
             **kwargs)
 
     def generate(self, params):
-        locale = params.pop('locale')
+        locale = params.pop('locale', None)
         subfaker = self._get_faker(locale)
         return subfaker.format(self.provider, **params)
 


### PR DESCRIPTION
Just ran into this after updating to the latest version of the code.   Likely to just be a typo.   

