### PR TITLE
Add Django 3.1 to the test matrix

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,9 @@ ChangeLog
 3.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+*New:*
+
+    - Add support for Django 3.1
 
 
 3.1.0 (2020-10-02)

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Framework :: Django :: 1.11
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0
+    Framework :: Django :: 3.1
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,8 @@ envlist =
     py{35,36,37,38}-django111-alchemy-mongoengine,
     py{35,36,37,38}-django22-alchemy-mongoengine,
     py{36,37,38}-django30-alchemy-mongoengine,
-    pypy3-django{111,22}-alchemy-mongoengine,
+    py{36,37,38}-django31-alchemy-mongoengine,
+    pypy3-django{111,22,30,31}-alchemy-mongoengine,
     docs
     examples
     linkcheck
@@ -17,7 +18,8 @@ deps =
     django111: Django>=1.11,<1.12
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
-    django{111,22,30}: Pillow
+    django31: Django>=3.1,<3.2
+    django{111,22,30,31}: Pillow
     alchemy: SQLAlchemy
     mongoengine: mongoengine
 


### PR DESCRIPTION
Django 3.1 was released August 4th, 2020.