### PR TITLE
Drop support for Django 1.11

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,9 @@ ChangeLog
 3.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+*Removed:*
+
+    - Drop support for Django 1.11. This version `is not maintained anymore <https://www.djangoproject.com/download/#supported-versions>`__.
 
 
 3.1.0 (2020-10-02)

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ license = MIT
 classifiers =
     Development Status :: 5 - Production/Stable
     Framework :: Django
-    Framework :: Django :: 1.11
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0
     Intended Audience :: Developers

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,9 @@
 minversion = 1.9
 envlist =
     lint
-    py{35,36,37,38}-django111-alchemy-mongoengine,
     py{35,36,37,38}-django22-alchemy-mongoengine,
     py{36,37,38}-django30-alchemy-mongoengine,
-    pypy3-django{111,22}-alchemy-mongoengine,
+    pypy3-django22-alchemy-mongoengine,
     docs
     examples
     linkcheck
@@ -14,10 +13,9 @@ toxworkdir = {env:TOX_WORKDIR:.tox}
 
 [testenv]
 deps =
-    django111: Django>=1.11,<1.12
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
-    django{111,22,30}: Pillow
+    django{22,30}: Pillow
     alchemy: SQLAlchemy
     mongoengine: mongoengine
 


### PR DESCRIPTION
Django 1.11 is no longer supported upstream.
https://www.djangoproject.com/download/#supported-versions