### PR TITLE
Do not override signals receivers registered during factory execution

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -39,6 +39,7 @@ The project has received contributions from (in alphabetical order):
 * Flavio Curella <flavio.curella@gmail.com>
 * François Freitag <mail@franek.fr>
 * George Hickman <george@ghickman.co.uk>
+* Grégoire Deveaux <gregoire.deveaux@backmarket.com>
 * Hervé Cauwelier <herve.cauwelier@polyconseil.fr>
 * Hugo Osvaldo Barrera <hugo@barrera.io>
 * Ilya Baryshev <baryshev@gmail.com>

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,10 @@ ChangeLog
 
     - Add support for Django 3.1
 
+*Bugfix:*
+
+    - Do not override signals receivers registered in a :meth:`~factory.django.mute_signals` context.
+
 *Removed:*
 
     - Drop support for Django 1.11. This version `is not maintained anymore <https://www.djangoproject.com/download/#supported-versions>`__.

--- a/factory/django.py
+++ b/factory/django.py
@@ -285,7 +285,7 @@ class mute_signals:
             logger.debug('mute_signals: Restoring signal handlers %r',
                          receivers)
 
-            signal.receivers = receivers
+            signal.receivers += receivers
             with signal.lock:
                 # Django uses some caching for its signals.
                 # Since we're bypassing signal.connect and signal.disconnect,

--- a/tests/djapp/models.py
+++ b/tests/djapp/models.py
@@ -6,6 +6,7 @@ import os.path
 
 from django.conf import settings
 from django.db import models
+from django.db.models import signals
 
 try:
     from PIL import Image
@@ -96,6 +97,14 @@ else:
 
 class WithSignals(models.Model):
     foo = models.CharField(max_length=20)
+
+    def __init__(self, post_save_signal_receiver=None):
+        super().__init__()
+        if post_save_signal_receiver:
+            signals.post_save.connect(
+                post_save_signal_receiver,
+                sender=self.__class__,
+            )
 
 
 class CustomManager(models.Manager):

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -884,6 +884,16 @@ class PreventSignalsTestCase(django_test.TestCase):
 
         self.assertSignalsReactivated()
 
+    def test_receiver_created_during_model_instantiation_is_not_lost(self):
+        with factory.django.mute_signals(signals.post_save):
+            instance = WithSignalsFactory(post_save_signal_receiver=self.handlers.created_during_instantiation)
+            self.assertTrue(self.handlers.created_during_instantiation.called)
+
+        self.handlers.created_during_instantiation.reset_mock()
+        instance.save()
+
+        self.assertTrue(self.handlers.created_during_instantiation.called)
+
     def test_signal_cache(self):
         with factory.django.mute_signals(signals.pre_save, signals.post_save):
             signals.post_save.connect(self.handlers.mute_block_receiver)


### PR DESCRIPTION
If a signal receiver is "connected" to a signal during a factory execution in a `mute_signals` context, this new connection to the signal is lost after the factory execution.
This can happen with receivers registered dynamically, during model instantiation for example.
This is the case when using the dirty fields library, see code [here](https://github.com/BackMarket/badoom/blob/170324fca16b7346f4ea9dc7635c96e10a810aa6/vendors/dirtyfields/dirtyfields.py#L34-L41)