### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,21 +12,22 @@ matrix:
     - python: "3.6"
     - python: "3.7"
     - python: "3.8"
+    - python: "3.9"
 
     - python: "pypy3"
 
     # Documentation
-    - python: "3.8"
+    - python: "3.9"
       env: TOXENV=docs
       before_install:
         - sudo apt-get -y install libenchant1c2a
-    - python: "3.8"
+    - python: "3.9"
       env: TOXENV=linkcheck
 
     # Linting
-    - python: "3.8"
+    - python: "3.9"
       env: TOXENV=examples
-    - python: "3.8"
+    - python: "3.9"
       env: TOXENV=lint
 
 services:

--- a/README.rst
+++ b/README.rst
@@ -318,7 +318,7 @@ The associated object's strategy will be used:
 Support Policy
 --------------
 
-``factory_boy`` supports Python 3.6 to 3.8 as well as PyPy3.
+``factory_boy`` supports active Python versions as well as PyPy3.
 
 - **Python**'s `supported versions
   <https://devguide.python.org/#status-of-python-branches>`__.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ ChangeLog
 *New:*
 
     - Add support for Django 3.1
+    - Add support for Python 3.9
 
 *Removed:*
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Software Development :: Testing

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 minversion = 1.9
 envlist =
     lint
-    py{36,37,38}-django22-alchemy-mongoengine,
-    py{36,37,38}-django30-alchemy-mongoengine,
-    py{36,37,38}-django31-alchemy-mongoengine,
+    py{36,37,38,39}-django22-alchemy-mongoengine,
+    py{36,37,38,39}-django30-alchemy-mongoengine,
+    py{36,37,38,39}-django31-alchemy-mongoengine,
     pypy3-django{22,30,31}-alchemy-mongoengine,
     docs
     examples
@@ -25,14 +25,14 @@ whitelist_externals = make
 commands = make test
 
 [testenv:docs]
-basepython = python3.8
+basepython = python3.9
 extras = doc
 
 whitelist_externals = make
 commands = make doc spelling
 
 [testenv:examples]
-basepython = python3.8
+basepython = python3.9
 deps =
     -rexamples/requirements.txt
 


### PR DESCRIPTION
The readme was updated not to mention the Python version explicitly, it
already links to the stable branches on the Python devguide for
supported version. That’s reduces the number of elements to upgrade for
next Python versions.

Use the latest Python version for all auxiliary builds (docs, example
test, etc). That allows using the latest features in these builds.