### PR TITLE
Use f-strings for simple string formatting

### DIFF
--- a/examples/flask_alchemy/demoapp.py
+++ b/examples/flask_alchemy/demoapp.py
@@ -33,4 +33,4 @@ class UserLog(db.Model):
         self.user = user
 
     def __repr__(self):
-        return '<Log for %r: %s>' % (self.user, self.message)
+        return f'<Log for {self.user!r}: {self.message}>'

--- a/factory/base.py
+++ b/factory/base.py
@@ -90,7 +90,7 @@ class FactoryMetaClass(type):
         if cls._meta.abstract:
             return '<%s (abstract)>' % cls.__name__
         else:
-            return '<%s for %s>' % (cls.__name__, cls._meta.model)
+            return f'<{cls.__name__} for {cls._meta.model}>'
 
 
 class BaseMeta:

--- a/factory/builder.py
+++ b/factory/builder.py
@@ -234,7 +234,7 @@ class BuildStep:
         return builder.build(parent_step=self, force_sequence=force_sequence)
 
     def __repr__(self):
-        return "<BuildStep for {!r}>".format(self.builder)
+        return f"<BuildStep for {self.builder!r}>"
 
 
 class StepBuilder:
@@ -314,7 +314,7 @@ class StepBuilder:
         return self.__class__(factory_meta, extras, strategy=self.strategy)
 
     def __repr__(self):
-        return "<StepBuilder(%r, strategy=%r)>" % (self.factory_meta, self.strategy)
+        return f"<StepBuilder({self.factory_meta!r}, strategy={self.strategy!r})>"
 
 
 class Resolver:

--- a/factory/declarations.py
+++ b/factory/declarations.py
@@ -393,9 +393,9 @@ class _FactoryWrapper:
 
     def __repr__(self):
         if self.factory is None:
-            return '<_FactoryImport: %s.%s>' % (self.module, self.name)
+            return f'<_FactoryImport: {self.module}.{self.name}>'
         else:
-            return '<_FactoryImport: %s>' % self.factory.__class__
+            return f'<_FactoryImport: {self.factory.__class__}>'
 
 
 class SubFactory(ParameteredAttribute):
@@ -490,7 +490,7 @@ class Maybe(BaseDeclaration):
         used_phases = {phase for phase in phases.values() if phase is not None}
 
         if len(used_phases) > 1:
-            raise TypeError("Inconsistent phases for %r: %r" % (self, phases))
+            raise TypeError(f"Inconsistent phases for {self!r}: {phases!r}")
 
         self.FACTORY_BUILDER_PHASE = used_phases.pop() if used_phases else enums.BuilderPhase.ATTRIBUTE_RESOLUTION
 
@@ -530,7 +530,7 @@ class Maybe(BaseDeclaration):
             return target
 
     def __repr__(self):
-        return 'Maybe(%r, yes=%r, no=%r)' % (self.decider, self.yes, self.no)
+        return f'Maybe({self.decider!r}, yes={self.yes!r}, no={self.no!r})'
 
 
 class Parameter(utils.OrderedBase):

--- a/factory/django.py
+++ b/factory/django.py
@@ -96,7 +96,7 @@ class DjangoModelFactory(base.Factory):
     def _get_manager(cls, model_class):
         if model_class is None:
             raise errors.AssociatedClassError(
-                "No model set on %s.%s.Meta" % (cls.__module__, cls.__name__))
+                f"No model set on {cls.__module__}.{cls.__name__}.Meta")
 
         try:
             manager = model_class.objects

--- a/tests/test_using.py
+++ b/tests/test_using.py
@@ -1507,7 +1507,7 @@ class SubFactoryTestCase(unittest.TestCase):
             two = factory.SubFactory(
                 TestModelFactory,
                 one=factory.Sequence(lambda n: 'x%dx' % n),
-                two=factory.LazyAttribute(lambda o: '%s%s' % (o.one, o.one)),
+                two=factory.LazyAttribute(lambda o: f'{o.one}{o.one}'),
             )
 
         test_model = TestModel2Factory(one=42)


### PR DESCRIPTION
Python f-strings were added in Python 3.6. factory_boy dropped support
for Python 3.5 in 64f10a18525572a5158b753d8f20195553fa5c5f.

Only simple expressions were changed. Normally f-strings are more
readable but with complex expressions they can sometimes get unwieldy.