### PR TITLE
docs: Update Many-to-Many Recipe to use bulk_add

### DIFF
--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -187,14 +187,12 @@ hook:
 
         @factory.post_generation
         def groups(self, create, extracted, **kwargs):
-            if not create:
-                # Simple build, do nothing.
+            if not create or not extracted:
+                # Simple build, or nothing to add, do nothing.
                 return
 
-            if extracted:
-                # A list of groups were passed in, use them
-                for group in extracted:
-                    self.groups.add(group)
+            # Add the iterable of groups using bulk addition
+            self.groups.add(*extracted)
 
 .. OHAI_VIM**
 


### PR DESCRIPTION
The given recipe will result in N queries, whereas add can do a bulk_add if given an iterable.

TODO: Does SQLAlchemy has something similar?

Open point: Should the documentation contain the `isinstance` check? I would even let it fail, but maybe explain or comment it?