### PR TITLE
Remove u prefix from strings in docs

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -72,8 +72,8 @@ And now, we'll define the related factories:
 
         account = factory.SubFactory(AccountFactory)
         gender = factory.Iterator([objects.Profile.GENDER_MALE, objects.Profile.GENDER_FEMALE])
-        firstname = u'John'
-        lastname = u'Doe'
+        firstname = 'John'
+        lastname = 'Doe'
 
 
 
@@ -86,7 +86,7 @@ If we commonly use a specific variant of our objects, we can refine a factory ac
 
     class FemaleProfileFactory(ProfileFactory):
         gender = objects.Profile.GENDER_FEMALE
-        firstname = u'Jane'
+        firstname = 'Jane'
         account__username = factory.Sequence(lambda n: 'jane%s' % n)
 
 

--- a/docs/orms.rst
+++ b/docs/orms.rst
@@ -432,7 +432,7 @@ A (very) simple example:
             sqlalchemy_session = session   # the SQLAlchemy session object
 
         id = factory.Sequence(lambda n: n)
-        name = factory.Sequence(lambda n: u'User %d' % n)
+        name = factory.Sequence(lambda n: 'User %d' % n)
 
 .. code-block:: pycon
 

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -132,9 +132,9 @@ Since version 2.9, the :meth:`~factory.django.mute_signals` decorator should be 
 
 .. code-block:: pycon
 
-    >>> u = UserFactory(profile__title=u"Lord")
+    >>> u = UserFactory(profile__title="Lord")
     >>> u.get_profile().title
-    u"Lord"
+    "Lord"
 
 Such behavior can be extended to other situations where a signal interferes with
 factory_boy related factories.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -883,7 +883,7 @@ return value of the method:
         class Meta:
             model = User
 
-        name = u"Jean"
+        name = "Jean"
 
         @factory.lazy_attribute
         def email(self):
@@ -891,13 +891,13 @@ return value of the method:
             clean_name = (unicodedata.normalize('NFKD', self.name)
                             .encode('ascii', 'ignore')
                             .decode('utf8'))
-            return u'%s@example.com' % clean_name
+            return '%s@example.com' % clean_name
 
 .. code-block:: pycon
 
-    >>> joel = UserFactory(name=u"Joël")
+    >>> joel = UserFactory(name="Joël")
     >>> joel.email
-    u'joel@example.com'
+    'joel@example.com'
 
 
 Sequence


### PR DESCRIPTION
Removes a Python-2-ism from docs. Python 2 has not been supported since
ea37bfeabe24113cc7ddb68b2886395f66541037 (release 3.0.0).