### PR TITLE
Deprecate factory.use_strategy()

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,24 @@
 ChangeLog
 =========
 
+4.0.0 (unreleased)
+------------------
+
+*Removed:*
+
+    - :func:`factory.use_strategy()`
+
+3.2.0 (unreleased)
+------------------
+
+*Deprecated:*
+
+    - :func:`factory.use_strategy`. Use :attr:`factory.FactoryOptions.strategy` instead.
+      The purpose of :func:`~factory.use_strategy` duplicates the factory option. Follow :pep:`20`: *There should be
+      one-- and preferably only one --obvious way to do it.*
+
+      :func:`~factory.use_strategy()` will be removed in the next major version.
+
 3.1.1 (unreleased)
 ------------------
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -590,6 +590,10 @@ factory_boy supports two main strategies for generating instances, plus stubs.
 
 .. function:: use_strategy(strategy)
 
+    .. deprecated:: 3.2
+
+        Use :py:attr:`factory.FactoryOptions.strategy` instead.
+
     *Decorator*
 
     Change the default strategy of the decorated :class:`Factory` to the chosen :obj:`strategy`:

--- a/factory/base.py
+++ b/factory/base.py
@@ -3,6 +3,7 @@
 
 import collections
 import logging
+import warnings
 
 from . import builder, declarations, enums, errors, utils
 
@@ -716,6 +717,11 @@ def use_strategy(new_strategy):
 
     This is an alternative to setting default_strategy in the class definition.
     """
+    warnings.warn(
+        "use_strategy() is deprecated and will be removed in the future.",
+        DeprecationWarning,
+    )
+
     def wrapped_class(klass):
         klass._meta.strategy = new_strategy
         return klass

--- a/tests/test_using.py
+++ b/tests/test_using.py
@@ -349,14 +349,13 @@ class UsingFactoryTestCase(unittest.TestCase):
         self.assertEqual(test_object.one, 'one')
 
     def test_inheriting_model_class(self):
-        @factory.use_strategy(factory.BUILD_STRATEGY)
         class TestObjectFactory(factory.Factory, TestObject):
             class Meta:
                 model = TestObject
 
             one = 'one'
 
-        test_object = TestObjectFactory()
+        test_object = TestObjectFactory.build()
         self.assertEqual(test_object.one, 'one')
 
     def test_abstract(self):


### PR DESCRIPTION
The purpose of this function is unclear. It is not used in the library
and not really tested.

Follow the Zen of Python, keep only one way of specifying a factory
default strategy: through its options. Users can define the strategy
when calling the factory with the dedicated methods (e.g.
`MyFactory.build()`, or `MyFactory.create()`).