### PR TITLE
Modify PyPI URLs to avoid redirects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,15 +9,15 @@ factory_boy
     :alt: Latest Version
 
 .. image:: https://img.shields.io/pypi/pyversions/factory_boy.svg
-    :target: https://pypi.org/project/factory_boy/
+    :target: https://pypi.org/project/factory-boy/
     :alt: Supported Python versions
 
 .. image:: https://img.shields.io/pypi/wheel/factory_boy.svg
-    :target: https://pypi.org/project/factory_boy/
+    :target: https://pypi.org/project/factory-boy/
     :alt: Wheel status
 
 .. image:: https://img.shields.io/pypi/l/factory_boy.svg
-    :target: https://pypi.org/project/factory_boy/
+    :target: https://pypi.org/project/factory-boy/
     :alt: License
 
 factory_boy is a fixtures replacement based on thoughtbot's `factory_bot <https://github.com/thoughtbot/factory_bot>`_.
@@ -77,14 +77,14 @@ Links
 
 * Documentation: https://factoryboy.readthedocs.io/
 * Repository: https://github.com/FactoryBoy/factory_boy
-* Package: https://pypi.org/project/factory_boy/
+* Package: https://pypi.org/project/factory-boy/
 * Mailing-list: `factoryboy@googlegroups.com <mailto:factoryboy@googlegroups.com>`_ | https://groups.google.com/forum/#!forum/factoryboy
 
 
 Download
 --------
 
-PyPI: https://pypi.org/project/factory_boy/
+PyPI: https://pypi.org/project/factory-boy/
 
 .. code-block:: sh
 


### PR DESCRIPTION
The URL https://pypi.org/project/factory_boy/ always redirects to
https://pypi.org/project/factory-boy/.

    $ curl -v -L --include -o /dev/null https://pypi.org/project/factory_boy/
    (abridged output)
    > GET /project/factory_boy/ HTTP/2
    < HTTP/2 301
    < location: https://pypi.org/project/factory-boy/
    > GET /project/factory-boy/ HTTP/2
    < HTTP/2 200

For whatever reason, the project is registered as factory-boy on PyPI
and changing that now would break the permanent redirects.

    $ curl -L https://pypi.org/pypi/factory_boy/json/ | jq .info.name
    "factory-boy"