### PR TITLE
Run tests against the next Django version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py{36,37,38,39,py3}-django22-alchemy-mongoengine
     py{36,37,38,39,py3}-django30-alchemy-mongoengine
     py{36,37,38,39,py3}-django31-alchemy-mongoengine
+    py39-djangomaster-alchemy-mongoengine
     docs
     examples
     linkcheck
@@ -16,7 +17,8 @@ deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
-    django{22,30,31}: Pillow
+    djangomaster: https://github.com/django/django/archive/master.tar.gz
+    django{22,30,31,master}: Pillow
     alchemy: SQLAlchemy
     mongoengine: mongoengine
 


### PR DESCRIPTION
Discover issues with the next release early. Only use the latest version
of Python, Django takes care of their supported Python versions.