### PR TITLE
Fix issues with Faker / locale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ build/
 dist/
 htmlcov/
 MANIFEST
+tags

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ SETUP_PY=setup.py
 COVERAGE = python $(shell which coverage)
 FLAKE8 = flake8
 ISORT = isort
+CTAGS = ctags
 
 
 all: default
@@ -85,6 +86,16 @@ coverage:
 
 
 .PHONY: test testall example-test lint coverage
+
+
+# Development
+# ===========
+
+# DOC: Generate a "tags" file
+TAGS:
+	$(CTAGS) --recurse $(PACKAGE) $(TESTS_DIR)
+
+.PHONY: TAGS
 
 
 # Documentation

--- a/factory/declarations.py
+++ b/factory/declarations.py
@@ -272,27 +272,11 @@ class ParameteredAttribute(BaseDeclaration):
     Attributes:
         defaults (dict): Default values for the parameters.
             May be overridden by call-time parameters.
-
-    Class attributes:
-        CONTAINERS_FIELD (str): name of the field, if any, where container
-            information (e.g for SubFactory) should be stored. If empty,
-            containers data isn't merged into generate() parameters.
     """
-
-    CONTAINERS_FIELD = '__containers'
-
-    # Whether to add the current object to the stack of containers
-    EXTEND_CONTAINERS = False
 
     def __init__(self, **kwargs):
         super().__init__()
         self.defaults = kwargs
-
-    def _prepare_containers(self, obj, containers=()):
-        if self.EXTEND_CONTAINERS:
-            return (obj,) + tuple(containers)
-
-        return containers
 
     def evaluate(self, instance, step, extra):
         """Evaluate the current definition and fill its attributes.
@@ -407,7 +391,6 @@ class SubFactory(ParameteredAttribute):
         factory (base.Factory): the wrapped factory
     """
 
-    EXTEND_CONTAINERS = True
     # Whether to align the attribute's sequence counter to the holding
     # factory's sequence counter
     FORCE_SEQUENCE = False

--- a/factory/declarations.py
+++ b/factory/declarations.py
@@ -377,7 +377,7 @@ class _FactoryWrapper:
             return f'<_FactoryImport: {self.factory.__class__}>'
 
 
-class SubFactory(ParameteredAttribute):
+class SubFactory(BaseDeclaration):
     """Base class for attributes based upon a sub-factory.
 
     Attributes:
@@ -399,7 +399,7 @@ class SubFactory(ParameteredAttribute):
         """Retrieve the wrapped factory.Factory subclass."""
         return self.factory_wrapper.get()
 
-    def generate(self, step, params):
+    def evaluate(self, instance, step, extra):
         """Evaluate the current definition and fill its attributes.
 
         Args:
@@ -411,11 +411,11 @@ class SubFactory(ParameteredAttribute):
         logger.debug(
             "SubFactory: Instantiating %s.%s(%s), create=%r",
             subfactory.__module__, subfactory.__name__,
-            utils.log_pprint(kwargs=params),
+            utils.log_pprint(kwargs=extra),
             step,
         )
         force_sequence = step.sequence if self.FORCE_SEQUENCE else None
-        return step.recurse(subfactory, params, force_sequence=force_sequence)
+        return step.recurse(subfactory, extra, force_sequence=force_sequence)
 
 
 class Dict(SubFactory):

--- a/factory/declarations.py
+++ b/factory/declarations.py
@@ -66,8 +66,8 @@ class LazyFunction(BaseDeclaration):
             returning the computed value.
     """
 
-    def __init__(self, function, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, function):
+        super().__init__()
         self.function = function
 
     def evaluate(self, instance, step, extra):
@@ -83,8 +83,8 @@ class LazyAttribute(BaseDeclaration):
             returning the computed value.
     """
 
-    def __init__(self, function, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, function):
+        super().__init__()
         self.function = function
 
     def evaluate(self, instance, step, extra):
@@ -138,8 +138,8 @@ class SelfAttribute(BaseDeclaration):
             exist.
     """
 
-    def __init__(self, attribute_name, default=_UNSPECIFIED, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, attribute_name, default=_UNSPECIFIED):
+        super().__init__()
         depth = len(attribute_name) - len(attribute_name.lstrip('.'))
         attribute_name = attribute_name[depth:]
 
@@ -246,8 +246,8 @@ class ContainerAttribute(BaseDeclaration):
         strict (bool): Whether evaluating should fail when the containers are
             not passed in (i.e used outside a SubFactory).
     """
-    def __init__(self, function, strict=True, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, function, strict=True):
+        super().__init__()
         self.function = function
         self.strict = strict
 

--- a/factory/declarations.py
+++ b/factory/declarations.py
@@ -320,29 +320,6 @@ class ParameteredAttribute(BaseDeclaration):
         raise NotImplementedError()
 
 
-class ParameteredDeclaration(BaseDeclaration):
-    """A declaration with parameters.
-
-    The parameters can be any factory-enabled declaration, and will be resolved
-    before the call to the user-defined code in `self.generate()`.
-
-    Attributes:
-        defaults (dict): Default values for the parameters; can be overridden
-            by call-time parameters. Accepts BaseDeclaration subclasses.
-    """
-
-    def evaluate(self, instance, step, extra):
-        return self.generate(extra)
-
-    def generate(self, params):
-        """Generate a value for this declaration.
-
-        Args:
-            params (dict): the parameters, after a factory evaluation.
-        """
-        raise NotImplementedError()
-
-
 class _FactoryWrapper:
     """Handle a 'factory' arg.
 

--- a/factory/django.py
+++ b/factory/django.py
@@ -173,7 +173,7 @@ class DjangoModelFactory(base.Factory):
             instance.save()
 
 
-class FileField(declarations.ParameteredDeclaration):
+class FileField(declarations.BaseDeclaration):
     """Helper to fill in django.db.models.FileField from a Factory."""
 
     DEFAULT_FILENAME = 'example.dat'
@@ -219,9 +219,9 @@ class FileField(declarations.ParameteredDeclaration):
         filename = params.get('filename', default_filename)
         return filename, content
 
-    def generate(self, params):
+    def evaluate(self, instance, step, extra):
         """Fill in the field."""
-        filename, content = self._make_content(params)
+        filename, content = self._make_content(extra)
         return django_files.File(content.file, filename)
 
 

--- a/factory/faker.py
+++ b/factory/faker.py
@@ -21,7 +21,7 @@ import faker.config
 from . import declarations
 
 
-class Faker(declarations.ParameteredDeclaration):
+class Faker(declarations.BaseDeclaration):
     """Wrapper for 'faker' values.
 
     Args:
@@ -42,10 +42,10 @@ class Faker(declarations.ParameteredDeclaration):
             locale=locale,
             **kwargs)
 
-    def generate(self, params):
-        locale = params.pop('locale')
+    def evaluate(self, instance, step, extra):
+        locale = extra.pop('locale')
         subfaker = self._get_faker(locale)
-        return subfaker.format(self.provider, **params)
+        return subfaker.format(self.provider, **extra)
 
     _FAKER_REGISTRY = {}
     _DEFAULT_LOCALE = faker.config.DEFAULT_LOCALE

--- a/factory/faker.py
+++ b/factory/faker.py
@@ -36,11 +36,14 @@ class Faker(declarations.ParameteredDeclaration):
         >>> foo = factory.Faker('name')
     """
     def __init__(self, provider, **kwargs):
+        locale = kwargs.pop('locale', None)
         self.provider = provider
-        super().__init__(**kwargs)
+        super().__init__(
+            locale=locale,
+            **kwargs)
 
     def generate(self, params):
-        locale = params.pop('locale', None)
+        locale = params.pop('locale')
         subfaker = self._get_faker(locale)
         return subfaker.format(self.provider, **params)
 

--- a/factory/fuzzy.py
+++ b/factory/fuzzy.py
@@ -39,8 +39,8 @@ class FuzzyAttribute(BaseFuzzyAttribute):
             random value.
     """
 
-    def __init__(self, fuzzer, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, fuzzer):
+        super().__init__()
         self.fuzzer = fuzzer
 
     def fuzz(self):
@@ -64,8 +64,8 @@ class FuzzyText(BaseFuzzyAttribute):
     not important.
     """
 
-    def __init__(self, prefix='', length=12, suffix='', chars=string.ascii_letters, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, prefix='', length=12, suffix='', chars=string.ascii_letters):
+        super().__init__()
         self.prefix = prefix
         self.suffix = suffix
         self.length = length
@@ -85,11 +85,11 @@ class FuzzyChoice(BaseFuzzyAttribute):
         getter (callable or None): a function to parse returned values
     """
 
-    def __init__(self, choices, getter=None, **kwargs):
+    def __init__(self, choices, getter=None):
         self.choices = None
         self.choices_generator = choices
         self.getter = getter
-        super().__init__(**kwargs)
+        super().__init__()
 
     def fuzz(self):
         if self.choices is None:
@@ -103,7 +103,7 @@ class FuzzyChoice(BaseFuzzyAttribute):
 class FuzzyInteger(BaseFuzzyAttribute):
     """Random integer within a given range."""
 
-    def __init__(self, low, high=None, step=1, **kwargs):
+    def __init__(self, low, high=None, step=1):
         if high is None:
             high = low
             low = 0
@@ -112,7 +112,7 @@ class FuzzyInteger(BaseFuzzyAttribute):
         self.high = high
         self.step = step
 
-        super().__init__(**kwargs)
+        super().__init__()
 
     def fuzz(self):
         return random.randgen.randrange(self.low, self.high + 1, self.step)
@@ -121,7 +121,7 @@ class FuzzyInteger(BaseFuzzyAttribute):
 class FuzzyDecimal(BaseFuzzyAttribute):
     """Random decimal within a given range."""
 
-    def __init__(self, low, high=None, precision=2, **kwargs):
+    def __init__(self, low, high=None, precision=2):
         if high is None:
             high = low
             low = 0.0
@@ -130,7 +130,7 @@ class FuzzyDecimal(BaseFuzzyAttribute):
         self.high = high
         self.precision = precision
 
-        super().__init__(**kwargs)
+        super().__init__()
 
     def fuzz(self):
         base = decimal.Decimal(str(random.randgen.uniform(self.low, self.high)))
@@ -140,7 +140,7 @@ class FuzzyDecimal(BaseFuzzyAttribute):
 class FuzzyFloat(BaseFuzzyAttribute):
     """Random float within a given range."""
 
-    def __init__(self, low, high=None, precision=15, **kwargs):
+    def __init__(self, low, high=None, precision=15):
         if high is None:
             high = low
             low = 0
@@ -149,7 +149,7 @@ class FuzzyFloat(BaseFuzzyAttribute):
         self.high = high
         self.precision = precision
 
-        super().__init__(**kwargs)
+        super().__init__()
 
     def fuzz(self):
         base = random.randgen.uniform(self.low, self.high)
@@ -159,8 +159,8 @@ class FuzzyFloat(BaseFuzzyAttribute):
 class FuzzyDate(BaseFuzzyAttribute):
     """Random date within a given date range."""
 
-    def __init__(self, start_date, end_date=None, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, start_date, end_date=None):
+        super().__init__()
         if end_date is None:
             if random.randgen.state_set:
                 cls_name = self.__class__.__name__
@@ -197,8 +197,8 @@ class BaseFuzzyDateTime(BaseFuzzyAttribute):
     def __init__(self, start_dt, end_dt=None,
                  force_year=None, force_month=None, force_day=None,
                  force_hour=None, force_minute=None, force_second=None,
-                 force_microsecond=None, **kwargs):
-        super().__init__(**kwargs)
+                 force_microsecond=None):
+        super().__init__()
 
         if end_dt is None:
             if random.randgen.state_set:

--- a/tests/test_faker.py
+++ b/tests/test_faker.py
@@ -50,7 +50,7 @@ class FakerTests(unittest.TestCase):
     def test_simple_biased(self):
         self._setup_mock_faker(name="John Doe")
         faker_field = factory.Faker('name')
-        self.assertEqual("John Doe", faker_field.generate({'locale': None}))
+        self.assertEqual("John Doe", faker_field.evaluate(None, None, {'locale': None}))
 
     def test_full_factory(self):
         class Profile:

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,0 +1,53 @@
+# Copyright: See the LICENSE file.
+
+
+"""Regression tests related to issues found with the project"""
+
+import datetime
+import typing as T
+import unittest
+
+import factory
+
+# Example objects
+# ===============
+
+
+class Author(T.NamedTuple):
+    fullname: str
+    pseudonym: T.Optional[str] = None
+
+
+class Book(T.NamedTuple):
+    title: str
+    author: Author
+
+
+class PublishedBook(T.NamedTuple):
+    book: Book
+    published_on: datetime.date
+    countries: T.List[str]
+
+
+class FakerRegressionTests(unittest.TestCase):
+    def test_locale_issue(self):
+        """Regression test for `KeyError: 'locale'`
+
+        See #785 #786 #787 #788 #790 #796.
+        """
+        class AuthorFactory(factory.Factory):
+            class Meta:
+                model = Author
+
+            class Params:
+                unknown = factory.Trait(
+                    fullname="",
+                )
+
+            fullname = factory.Faker("name")
+
+        public_author = AuthorFactory(unknown=False)
+        self.assertIsNone(public_author.pseudonym)
+
+        unknown_author = AuthorFactory(unknown=True)
+        self.assertEqual("", unknown_author.fullname)


### PR DESCRIPTION
The issue stemmed from `factory.Maybe` not properly unrolling the context of the wrapped declarations.

This has been fixed by moving most of the unrolling calls into the declaration itself - through more explicit `evaluate_pre` and `evaluate_post` interface endpoints.

On the way, the `ParameteredDeclaration` subclass has been removed — its features merged into the main `BaseDeclaration` class.