### PR TITLE
Set long description content type

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,8 @@ name = factory_boy
 version = 3.2.1.dev0
 description = A versatile test fixtures replacement based on thoughtbot's factory_bot for Ruby.
 long_description = file: README.rst
+# https://docutils.sourceforge.io/FAQ.html#what-s-the-official-mime-type-for-restructuredtext-data
+long_description_content_type = text/x-rst
 author = Mark Sandstrom
 author_email = mark@deliciouslynerdy.com
 maintainer = Raphaël Barrois


### PR DESCRIPTION
Fixes twine check warning:

```
Checking dist/factory_boy-3.2.1.dev0.tar.gz: PASSED, with warnings
  warning: `long_description_content_type` missing. defaulting to `text/x-rst`.
```