### PR TITLE
Avoid argument name clashing with a field with the same name

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -72,6 +72,7 @@ The project has received contributions from (in alphabetical order):
 * Samuel Paccoud <samuel@sampaccoud.com>
 * Saul Shanabrook <s.shanabrook@gmail.com>
 * Sean Löfgren <SeanBE@users.noreply.github.com>
+* Shahriar Tajbakhsh <shahriar@metaview.ai>
 * Tom <tom@tomleo.com>
 * alex-netquity <alex@netquity.com>
 * anentropic <ego@anentropic.com>

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,7 +34,7 @@ ChangeLog
 *Bug fix:*
 
     - :issue:`775`: Change the signature for :meth:`~factory.alchemy.SQLAlchemyModelFactory._save` and
-      :meth:`~factory.alchemy.SQLAlchemyModelFactory._get_or_create`to avoid argument names clashing
+      :meth:`~factory.alchemy.SQLAlchemyModelFactory._get_or_create` to avoid argument names clashing
       with a field with the same name.
 
 *Removed:*

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,12 @@ ChangeLog
           - override :class:`~factory.django.DjangoModelFactory._after_postgeneration` to
             :meth:`~django.db.models.Model.save` the instance.
 
+*Bug fix:*
+
+    - :issue:`775`: Change the signature for :meth:`~factory.alchemy.SQLAlchemyModelFactory._save` and
+      :meth:`~factory.alchemy.SQLAlchemyModelFactory._get_or_create`to avoid argument names clashing
+      with a field with the same name.
+
 *Removed:*
 
 3.2.0 (2020-12-28)

--- a/factory/alchemy.py
+++ b/factory/alchemy.py
@@ -66,7 +66,7 @@ class SQLAlchemyModelFactory(base.Factory):
 
         if not obj:
             try:
-                obj = cls._save(model_class, session, *args, **key_fields, **kwargs)
+                obj = cls._save(model_class, session, args, {**key_fields, **kwargs})
             except IntegrityError as e:
                 session.rollback()
                 get_or_create_params = {
@@ -96,16 +96,16 @@ class SQLAlchemyModelFactory(base.Factory):
             raise RuntimeError("No session provided.")
         if cls._meta.sqlalchemy_get_or_create:
             return cls._get_or_create(model_class, session, *args, **kwargs)
-        return cls._save(model_class, session, *args, **kwargs)
+        return cls._save(model_class, session, args, kwargs)
 
     @classmethod
-    def _save(cls, model_class, sqlalchemy_session, *args, **kwargs):
+    def _save(cls, model_class, session, args, kwargs):
         session_persistence = cls._meta.sqlalchemy_session_persistence
 
         obj = model_class(*args, **kwargs)
-        sqlalchemy_session.add(obj)
+        session.add(obj)
         if session_persistence == SESSION_PERSISTENCE_FLUSH:
-            sqlalchemy_session.flush()
+            session.flush()
         elif session_persistence == SESSION_PERSISTENCE_COMMIT:
-            sqlalchemy_session.commit()
+            session.commit()
         return obj

--- a/factory/alchemy.py
+++ b/factory/alchemy.py
@@ -51,7 +51,7 @@ class SQLAlchemyModelFactory(base.Factory):
         return super()._generate(strategy, params)
 
     @classmethod
-    def _get_or_create(cls, model_class, session, *args, **kwargs):
+    def _get_or_create(cls, model_class, session, args, kwargs):
         key_fields = {}
         for field in cls._meta.sqlalchemy_get_or_create:
             if field not in kwargs:
@@ -95,7 +95,7 @@ class SQLAlchemyModelFactory(base.Factory):
         if session is None:
             raise RuntimeError("No session provided.")
         if cls._meta.sqlalchemy_get_or_create:
-            return cls._get_or_create(model_class, session, *args, **kwargs)
+            return cls._get_or_create(model_class, session, args, kwargs)
         return cls._save(model_class, session, args, kwargs)
 
     @classmethod

--- a/factory/alchemy.py
+++ b/factory/alchemy.py
@@ -99,13 +99,13 @@ class SQLAlchemyModelFactory(base.Factory):
         return cls._save(model_class, session, *args, **kwargs)
 
     @classmethod
-    def _save(cls, model_class, session, *args, **kwargs):
+    def _save(cls, model_class, sqlalchemy_session, *args, **kwargs):
         session_persistence = cls._meta.sqlalchemy_session_persistence
 
         obj = model_class(*args, **kwargs)
-        session.add(obj)
+        sqlalchemy_session.add(obj)
         if session_persistence == SESSION_PERSISTENCE_FLUSH:
-            session.flush()
+            sqlalchemy_session.flush()
         elif session_persistence == SESSION_PERSISTENCE_COMMIT:
-            session.commit()
+            sqlalchemy_session.commit()
         return obj

--- a/tests/alchemyapp/models.py
+++ b/tests/alchemyapp/models.py
@@ -43,4 +43,11 @@ class NonIntegerPk(Base):
     id = Column(Unicode(20), primary_key=True)
 
 
+class SpecialFieldModel(Base):
+    __tablename__ = 'SpecialFieldModelTable'
+
+    id = Column(Integer(), primary_key=True)
+    session = Column(Unicode(20))
+
+
 Base.metadata.create_all(engine)

--- a/tests/test_alchemy.py
+++ b/tests/test_alchemy.py
@@ -264,24 +264,31 @@ class SQLAlchemyNoSessionTestCase(unittest.TestCase):
 
 
 class NameConflictTests(unittest.TestCase):
-    def test_name_conflict_issue(self):
-        """Regression test for `TypeError: _save() got multiple values for argument 'session'`
+    """Regression test for `TypeError: _save() got multiple values for argument 'session'`
 
-        See #775.
-        """
-        class SpecialFieldModel(models.Base):
-            __tablename__ = 'SpecialFieldModelTable'
-
-            id = models.Column(models.Integer(), primary_key=True)
-            session = models.Column(models.Unicode(20))
-
-        class ChildFactory(SQLAlchemyModelFactory):
+    See #775.
+    """
+    def test_no_name_conflict_on_save(self):
+        class SpecialFieldWithSaveFactory(SQLAlchemyModelFactory):
             class Meta:
-                model = SpecialFieldModel
+                model = models.SpecialFieldModel
                 sqlalchemy_session = models.session
 
             id = factory.Sequence(lambda n: n)
             session = ''
 
-        child = ChildFactory()
-        self.assertIsNotNone(child.session)
+        saved_child = SpecialFieldWithSaveFactory()
+        self.assertIsNotNone(saved_child.session)
+    
+    def test_no_name_conflict_on_get_or_create(self):       
+        class SpecialFieldWithGetOrCreateFactory(SQLAlchemyModelFactory):
+            class Meta:
+                model = models.SpecialFieldModel
+                sqlalchemy_get_or_create = ('session',)
+                sqlalchemy_session = models.session
+
+            id = factory.Sequence(lambda n: n)
+            session = ''
+
+        get_or_created_child = SpecialFieldWithGetOrCreateFactory()
+        self.assertIsNotNone(get_or_created_child.session)

--- a/tests/test_alchemy.py
+++ b/tests/test_alchemy.py
@@ -279,8 +279,8 @@ class NameConflictTests(unittest.TestCase):
 
         saved_child = SpecialFieldWithSaveFactory()
         self.assertIsNotNone(saved_child.session)
-    
-    def test_no_name_conflict_on_get_or_create(self):       
+
+    def test_no_name_conflict_on_get_or_create(self):
         class SpecialFieldWithGetOrCreateFactory(SQLAlchemyModelFactory):
             class Meta:
                 model = models.SpecialFieldModel

--- a/tests/test_alchemy.py
+++ b/tests/test_alchemy.py
@@ -261,3 +261,27 @@ class SQLAlchemyNoSessionTestCase(unittest.TestCase):
         inst1 = NoSessionFactory.build()
         self.assertEqual(inst0.id, 0)
         self.assertEqual(inst1.id, 1)
+
+
+class NameConflictTests(unittest.TestCase):
+    def test_name_conflict_issue(self):
+        """Regression test for `TypeError: _save() got multiple values for argument 'session'`
+
+        See #775.
+        """
+        class SpecialFieldModel(models.Base):
+            __tablename__ = 'SpecialFieldModelTable'
+
+            id = models.Column(models.Integer(), primary_key=True)
+            session = models.Column(models.Unicode(20))
+
+        class ChildFactory(SQLAlchemyModelFactory):
+            class Meta:
+                model = SpecialFieldModel
+                sqlalchemy_session = models.session
+
+            id = factory.Sequence(lambda n: n)
+            session = ''
+
+        child = ChildFactory()
+        self.assertIsNotNone(child.session)

--- a/tests/test_alchemy.py
+++ b/tests/test_alchemy.py
@@ -278,7 +278,7 @@ class NameConflictTests(unittest.TestCase):
             session = ''
 
         saved_child = SpecialFieldWithSaveFactory()
-        self.assertIsNotNone(saved_child.session)
+        self.assertEqual(saved_child.session, "")
 
     def test_no_name_conflict_on_get_or_create(self):
         class SpecialFieldWithGetOrCreateFactory(SQLAlchemyModelFactory):
@@ -291,4 +291,4 @@ class NameConflictTests(unittest.TestCase):
             session = ''
 
         get_or_created_child = SpecialFieldWithGetOrCreateFactory()
-        self.assertIsNotNone(get_or_created_child.session)
+        self.assertEqual(get_or_created_child.session, "")

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -67,7 +67,6 @@ class NameConflictTests(unittest.TestCase):
 
             id = models.Column(models.Integer(), primary_key=True)
             session = models.Column(models.Unicode(20))
-            model_class = models.Column(models.Unicode(20))
 
         class ChildFactory(SQLAlchemyModelFactory):
             class Meta:

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -54,27 +54,3 @@ class FakerRegressionTests(unittest.TestCase):
 
         unknown_author = AuthorFactory(unknown=True)
         self.assertEqual("", unknown_author.fullname)
-
-
-class NameConflictTests(unittest.TestCase):
-    def test_name_conflict_issue(self):
-        """Regression test for `TypeError: _save() got multiple values for argument 'x'`
-
-        See #775.
-        """
-        class SpecialFieldModel(models.Base):
-            __tablename__ = 'SpecialFieldModelTable'
-
-            id = models.Column(models.Integer(), primary_key=True)
-            session = models.Column(models.Unicode(20))
-
-        class ChildFactory(SQLAlchemyModelFactory):
-            class Meta:
-                model = SpecialFieldModel
-                sqlalchemy_session = models.session
-
-            id = factory.Sequence(lambda n: n)
-            session = ''
-
-        child = ChildFactory()
-        self.assertIsNotNone(child.session)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -62,7 +62,6 @@ class NameConflictTests(unittest.TestCase):
 
         See #775.
         """
-
         class SpecialFieldModel(models.Base):
             __tablename__ = 'SpecialFieldModelTable'
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -8,9 +8,6 @@ import typing as T
 import unittest
 
 import factory
-from factory.alchemy import SQLAlchemyModelFactory
-
-from .alchemyapp import models
 
 # Example objects
 # ===============


### PR DESCRIPTION
Resolves https://github.com/FactoryBoy/factory_boy/issues/775

It's not uncommon to have a SQLAlchemy relationship called `session`. When that's the case, whenever one tries to create an instance with factory_boy and passes in the `session` relationship to the factory, one will get an exception saying that multiple sessions were passed into `SQLAlchemyModelFactory._save`.