### PR TITLE
Avoid SQLAlchemyModelFactory name clash with a field named session

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -73,6 +73,7 @@ The project has received contributions from (in alphabetical order):
 * Samuel Paccoud <samuel@sampaccoud.com>
 * Saul Shanabrook <s.shanabrook@gmail.com>
 * Sean Löfgren <SeanBE@users.noreply.github.com>
+* Shahriar Tajbakhsh <shahriar@metaview.ai>
 * Tom <tom@tomleo.com>
 * alex-netquity <alex@netquity.com>
 * anentropic <ego@anentropic.com>

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,10 @@ ChangeLog
 
     - Do not override signals receivers registered in a :meth:`~factory.django.mute_signals` context.
 
+    - :issue:`775`: Change the signature for :meth:`~factory.alchemy.SQLAlchemyModelFactory._save` and
+      :meth:`~factory.alchemy.SQLAlchemyModelFactory._get_or_create` to avoid argument names clashes with a field named
+      ``session``.
+
 *Deprecated:*
 
     - :class:`~factory.django.DjangoModelFactory` will stop issuing a second call to

--- a/factory/alchemy.py
+++ b/factory/alchemy.py
@@ -51,7 +51,7 @@ class SQLAlchemyModelFactory(base.Factory):
         return super()._generate(strategy, params)
 
     @classmethod
-    def _get_or_create(cls, model_class, session, *args, **kwargs):
+    def _get_or_create(cls, model_class, session, args, kwargs):
         key_fields = {}
         for field in cls._meta.sqlalchemy_get_or_create:
             if field not in kwargs:
@@ -66,7 +66,7 @@ class SQLAlchemyModelFactory(base.Factory):
 
         if not obj:
             try:
-                obj = cls._save(model_class, session, *args, **key_fields, **kwargs)
+                obj = cls._save(model_class, session, args, {**key_fields, **kwargs})
             except IntegrityError as e:
                 session.rollback()
                 get_or_create_params = {
@@ -95,11 +95,11 @@ class SQLAlchemyModelFactory(base.Factory):
         if session is None:
             raise RuntimeError("No session provided.")
         if cls._meta.sqlalchemy_get_or_create:
-            return cls._get_or_create(model_class, session, *args, **kwargs)
-        return cls._save(model_class, session, *args, **kwargs)
+            return cls._get_or_create(model_class, session, args, kwargs)
+        return cls._save(model_class, session, args, kwargs)
 
     @classmethod
-    def _save(cls, model_class, session, *args, **kwargs):
+    def _save(cls, model_class, session, args, kwargs):
         session_persistence = cls._meta.sqlalchemy_session_persistence
 
         obj = model_class(*args, **kwargs)

--- a/tests/alchemyapp/models.py
+++ b/tests/alchemyapp/models.py
@@ -43,4 +43,11 @@ class NonIntegerPk(Base):
     id = Column(Unicode(20), primary_key=True)
 
 
+class SpecialFieldModel(Base):
+    __tablename__ = 'SpecialFieldModelTable'
+
+    id = Column(Integer(), primary_key=True)
+    session = Column(Unicode(20))
+
+
 Base.metadata.create_all(engine)

--- a/tests/test_alchemy.py
+++ b/tests/test_alchemy.py
@@ -261,3 +261,34 @@ class SQLAlchemyNoSessionTestCase(unittest.TestCase):
         inst1 = NoSessionFactory.build()
         self.assertEqual(inst0.id, 0)
         self.assertEqual(inst1.id, 1)
+
+
+class NameConflictTests(unittest.TestCase):
+    """Regression test for `TypeError: _save() got multiple values for argument 'session'`
+
+    See #775.
+    """
+    def test_no_name_conflict_on_save(self):
+        class SpecialFieldWithSaveFactory(SQLAlchemyModelFactory):
+            class Meta:
+                model = models.SpecialFieldModel
+                sqlalchemy_session = models.session
+
+            id = factory.Sequence(lambda n: n)
+            session = ''
+
+        saved_child = SpecialFieldWithSaveFactory()
+        self.assertEqual(saved_child.session, "")
+
+    def test_no_name_conflict_on_get_or_create(self):
+        class SpecialFieldWithGetOrCreateFactory(SQLAlchemyModelFactory):
+            class Meta:
+                model = models.SpecialFieldModel
+                sqlalchemy_get_or_create = ('session',)
+                sqlalchemy_session = models.session
+
+            id = factory.Sequence(lambda n: n)
+            session = ''
+
+        get_or_created_child = SpecialFieldWithGetOrCreateFactory()
+        self.assertEqual(get_or_created_child.session, "")


### PR DESCRIPTION
Internal helpers `_create` and `_get_or_create` expected to receive the
SQLAlchemy session as a keyword argument. Passing a value for a field
named session as a keyword argument to a SQLAlchemyModelFactory subclass
caused a name clash:

TypeError: got multiple values for keyword argument 'session'.

Fix #775