### PR TITLE
Fuzzy decimal using decimals

### DIFF
--- a/docs/fuzzy.rst
+++ b/docs/fuzzy.rst
@@ -132,32 +132,79 @@ FuzzyDecimal
     The :class:`FuzzyDecimal` fuzzer generates random :class:`decimals <decimal.Decimal>` within a given
     inclusive range.
 
+    .. note::
+        Providing decimals as argument will result in a :exc:`TypeError`. Use :class:`~factory.fuzzy.FuzzyDecimalDec`
+        instead.
+
     The :attr:`low` bound may be omitted, in which case it defaults to 0:
 
     .. code-block:: pycon
 
-        >>> FuzzyDecimal(0.5, 42.7)
-        >>> fi.low, fi.high
+        >>> fd = FuzzyDecimal(0.5, 42.7)
+        >>> fd.low, fd.high
         0.5, 42.7
 
-        >>> fi = FuzzyDecimal(42.7)
-        >>> fi.low, fi.high
+        >>> fd = FuzzyDecimal(42.7)
+        >>> fd.low, fd.high
         0.0, 42.7
 
-        >>> fi = FuzzyDecimal(0.5, 42.7, 3)
-        >>> fi.low, fi.high, fi.precision
+        >>> fd = FuzzyDecimal(0.5, 42.7, 3)
+        >>> fd.low, fd.high, fd.precision
         0.5, 42.7, 3
 
     .. attribute:: low
 
-        decimal, the inclusive lower bound of generated decimals
+        float or int, the inclusive lower bound of generated decimals
 
     .. attribute:: high
 
-        decimal, the inclusive higher bound of generated decimals
+        float or int, the inclusive higher bound of generated decimals
 
     .. attribute:: precision
-        int, the number of digits to generate after the dot. The default is 2 digits.
+
+        int, the number of digits after the decimal separator. The default is 2.
+
+
+FuzzyDecimalDec
+---------------
+
+.. class:: FuzzyDecimalDec(low[, high[, precision=2]])
+
+    The :class:`FuzzyDecimalDec` fuzzer generates random :class:`decimals <decimal.Decimal>` within a given
+    inclusive range, accepting any argument that the constructor of the :class:`decimal <decimal.Decimal>`
+    accepts.
+
+    .. note::
+        One purpose of this class is accuracy. Providing inaccurate arguments (:class:`floats <float>`), will result in
+        inaccurate bounds. In that case it's better to use :class:`~factory.fuzzy.FuzzyDecimal` instead.
+
+    The :attr:`low` bound may be omitted, in which case it defaults to 0:
+
+    .. code-block:: pycon
+
+        >>> fd = FuzzyDecimalDec('0.5', Decimal('42.7'))
+        >>> fd.low, fd.high
+        Decimal('0.5'), Decimal('42.7')
+
+        >>> fd = FuzzyDecimalDec(42.7)
+        >>> fd.low, fd.high
+        Decimal('0'), Decimal('42.7000000000000028421709430404007434844970703125')
+
+        >>> fd = FuzzyDecimalDec('0.5', '42.7', 3)
+        >>> fd.low, fd.high, fd.precision
+        Decimal('0.5'), Decimal('42.7'), 3
+
+    .. attribute:: low
+
+        string, Decimal or int, the inclusive lower bound of generated decimals
+
+    .. attribute:: high
+
+        string, Decimal or int, the inclusive higher bound of generated decimals
+
+    .. attribute:: precision
+
+        int, the number of digits after the decimal separator. The default is 2.
 
 
 FuzzyFloat

--- a/factory/fuzzy.py
+++ b/factory/fuzzy.py
@@ -126,8 +126,8 @@ class FuzzyDecimal(BaseFuzzyAttribute):
             high = low
             low = 0.0
 
-        self.low = low
-        self.high = high
+        self.low = float(low)
+        self.high = float(high)
         self.precision = precision
 
         super().__init__()

--- a/factory/fuzzy.py
+++ b/factory/fuzzy.py
@@ -136,6 +136,7 @@ class FuzzyDecimal(BaseFuzzyAttribute):
         base = decimal.Decimal(str(random.randgen.uniform(self.low, self.high)))
         return base.quantize(decimal.Decimal(10) ** -self.precision)
 
+
 class FuzzyDecimalDec(BaseFuzzyAttribute):
     """Random decimal within a given range, accepting decimal-like arguments."""
     def __init__(self, low, high=None, precision=2):

--- a/factory/fuzzy.py
+++ b/factory/fuzzy.py
@@ -126,14 +126,31 @@ class FuzzyDecimal(BaseFuzzyAttribute):
             high = low
             low = 0.0
 
-        self.low = float(low)
-        self.high = float(high)
+        self.low = low
+        self.high = high
         self.precision = precision
 
         super().__init__()
 
     def fuzz(self):
         base = decimal.Decimal(str(random.randgen.uniform(self.low, self.high)))
+        return base.quantize(decimal.Decimal(10) ** -self.precision)
+
+class FuzzyDecimalDec(BaseFuzzyAttribute):
+    """Random decimal within a given range, accepting decimal-like arguments."""
+    def __init__(self, low, high=None, precision=2):
+        if high is None:
+            high = low
+            low = decimal.Decimal('0')
+
+        self.low = decimal.Decimal(low)
+        self.high = decimal.Decimal(high)
+        self.precision = precision
+
+        super().__init__()
+
+    def fuzz(self):
+        base = random.uniform_decimal(self.low, self.high)
         return base.quantize(decimal.Decimal(10) ** -self.precision)
 
 

--- a/factory/random.py
+++ b/factory/random.py
@@ -1,3 +1,4 @@
+import decimal
 import random
 
 import faker.generator
@@ -28,3 +29,7 @@ def reseed_random(seed):
     r = random.Random(seed)
     random_internal_state = r.getstate()
     set_random_state(random_internal_state)
+
+def uniform_decimal(low, high):
+    modifier = decimal.Decimal(randgen.random())
+    return low + (high - low) * modifier

--- a/factory/random.py
+++ b/factory/random.py
@@ -30,6 +30,7 @@ def reseed_random(seed):
     random_internal_state = r.getstate()
     set_random_state(random_internal_state)
 
+
 def uniform_decimal(low, high):
     modifier = decimal.Decimal(randgen.random())
     return low + (high - low) * modifier

--- a/tests/test_fuzzy.py
+++ b/tests/test_fuzzy.py
@@ -8,6 +8,7 @@ import warnings
 from unittest import mock
 
 from factory import fuzzy, random
+
 from . import utils
 
 
@@ -200,6 +201,7 @@ class FuzzyDecimalTestCase(unittest.TestCase):
         with self.assertRaises(TypeError):
             utils.evaluate_declaration(fuzz)
 
+
 class FuzzyDecimalDecTestCase(unittest.TestCase):
     def test_definition(self):
         """Tests all ways of defining a FuzzyDecimal."""
@@ -278,6 +280,7 @@ class FuzzyDecimalDecTestCase(unittest.TestCase):
 
         res = utils.evaluate_declaration(fuzz)
         self.assertTrue(low <= res <= high, "value %d is not between 5.5 and 10" % res)
+
 
 class FuzzyFloatTestCase(unittest.TestCase):
     def test_definition(self):

--- a/tests/test_fuzzy.py
+++ b/tests/test_fuzzy.py
@@ -8,7 +8,6 @@ import warnings
 from unittest import mock
 
 from factory import fuzzy, random
-
 from . import utils
 
 
@@ -193,6 +192,92 @@ class FuzzyDecimalTestCase(unittest.TestCase):
         finally:
             decimal_context.traps[decimal.FloatOperation] = old_traps
 
+    def test_decimal_args(self):
+        low = decimal.Decimal('5.5')
+        high = decimal.Decimal('10')
+        fuzz = fuzzy.FuzzyDecimal(low, high)
+
+        with self.assertRaises(TypeError):
+            utils.evaluate_declaration(fuzz)
+
+class FuzzyDecimalDecTestCase(unittest.TestCase):
+    def test_definition(self):
+        """Tests all ways of defining a FuzzyDecimal."""
+        fuzz = fuzzy.FuzzyDecimalDec('2.0', decimal.Decimal('3.0'))
+        for _i in range(20):
+            res = utils.evaluate_declaration(fuzz)
+            self.assertTrue(
+                decimal.Decimal('2.0') <= res <= decimal.Decimal('3.0'),
+                "value %d is not between 2.0 and 3.0" % res,
+            )
+
+        fuzz = fuzzy.FuzzyDecimalDec(4.0)
+        for _i in range(20):
+            res = utils.evaluate_declaration(fuzz)
+            self.assertTrue(
+                decimal.Decimal('0.0') <= res <= decimal.Decimal('4.0'),
+                "value %d is not between 0.0 and 4.0" % res,
+            )
+
+        fuzz = fuzzy.FuzzyDecimalDec(1.0, '4.0', precision=5)
+        for _i in range(20):
+            res = utils.evaluate_declaration(fuzz)
+            self.assertTrue(
+                decimal.Decimal('1.0') <= res <= decimal.Decimal('4.0'),
+                "value %d is not between 1.0 and 4.0" % res,
+            )
+            self.assertTrue(res.as_tuple().exponent, -5)
+
+    def test_biased(self):
+        fake_uniform = lambda low, high: low + high
+
+        fuzz = fuzzy.FuzzyDecimalDec(decimal.Decimal('2.0'), decimal.Decimal('8.0'))
+
+        with mock.patch('factory.random.uniform_decimal', fake_uniform):
+            res = utils.evaluate_declaration(fuzz)
+
+        self.assertEqual(decimal.Decimal('10.0'), res)
+        fuzz = fuzzy.FuzzyDecimalDec('2.0', '8.0')
+
+        with mock.patch('factory.random.uniform_decimal', fake_uniform):
+            res = utils.evaluate_declaration(fuzz)
+
+        self.assertEqual(decimal.Decimal('10.0'), res)
+
+        fuzz = fuzzy.FuzzyDecimalDec(3.33, 20 / 3, precision=2)
+
+        with mock.patch('factory.random.uniform_decimal', fake_uniform):
+            res = utils.evaluate_declaration(fuzz)
+
+        self.assertEqual(decimal.Decimal('10.00'), res)
+
+    def test_biased_high_only(self):
+        fake_uniform = lambda low, high: low + high
+
+        fuzz = fuzzy.FuzzyDecimalDec('8.0')
+
+        with mock.patch('factory.random.uniform_decimal', fake_uniform):
+            res = utils.evaluate_declaration(fuzz)
+
+        self.assertEqual(decimal.Decimal('8.0'), res)
+
+    def test_precision(self):
+        fake_uniform = lambda low, high: low + high + decimal.Decimal('0.001')
+
+        fuzz = fuzzy.FuzzyDecimalDec('8.0', precision=3)
+
+        with mock.patch('factory.random.uniform_decimal', fake_uniform):
+            res = utils.evaluate_declaration(fuzz)
+
+        self.assertEqual(decimal.Decimal('8.001').quantize(decimal.Decimal(10) ** -3), res)
+
+    def test_decimal_args(self):
+        low = decimal.Decimal('5.5')
+        high = decimal.Decimal('10')
+        fuzz = fuzzy.FuzzyDecimalDec(low, high)
+
+        res = utils.evaluate_declaration(fuzz)
+        self.assertTrue(low <= res <= high, "value %d is not between 5.5 and 10" % res)
 
 class FuzzyFloatTestCase(unittest.TestCase):
     def test_definition(self):


### PR DESCRIPTION
Add FuzzyDecimalDec:  a random decimal generator that is bound by decimals.

Use cases:
- bounds are set by model fields that have decimal values, such as generating the amount used of a budget (easy of use)
- bounds are assumed to be precise and part of complex calculations, which can result in incorrect test results, due to rounding (accuracy)

Implementation:
- Converts bounds arguments to decimals before calculating the value
- Reimplements random.Random().uniform() to avoid the TypeError caused by random.Random().random() returning floats.

