### PR TITLE
Restore Django main build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ jobs:
           - django22-alchemy-mongoengine
           - django31-alchemy-mongoengine
           - django32-alchemy-mongoengine
+        include:
+          - python-version: 3.9
+            tox-environment: djangomain-alchemy-mongoengine
 
     services:
       mongodb:

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,8 @@ deps =
     django22: Django>=2.2,<2.3
     django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
-    djangomaster: https://github.com/django/django/archive/master.tar.gz
-    django{22,31,32,master}: Pillow
+    djangomain: https://github.com/django/django/archive/main.tar.gz
+    django{22,31,32,main}: Pillow
     alchemy: SQLAlchemy
     mongoengine: mongoengine
 


### PR DESCRIPTION
The build was not ported to GitHub actions in
d8b241c94c326ce6c241cf8b6c7c8745599e4583.

In the meantime, Django renamed their development branch from master to
main.