### PR TITLE
Earlier FactoryOptions init for meta class extendibility, fixes #857  

### DIFF
--- a/factory/base.py
+++ b/factory/base.py
@@ -234,7 +234,6 @@ class FactoryOptions:
         self._check_parameter_dependencies(self.parameters)
         self.pre_declarations, self.post_declarations = builder.parse_declarations(self.declarations)
 
-
     def _get_counter_reference(self):
         """Identify which factory should be used for a shared counter."""
 


### PR DESCRIPTION
Initilize the FactoryOptions earlier so that metaclasses that uses Factory classes as base can add their own pre-init configuration, fixes #857