### PR TITLE
Fix a typo in docs.

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -718,7 +718,7 @@ Faker
 
     .. code-block:: python
 
-        class TripFactory(fatory.Factory):
+        class TripFactory(factory.Factory):
             class Meta:
                 model = Trip
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -703,7 +703,7 @@ Faker
 
     .. code-block:: python
 
-        class UserFactory(fatory.Factory):
+        class UserFactory(factory.Factory):
             class Meta:
                 model = User
 


### PR DESCRIPTION
I was reading the docs for the Faker object and found this typo. This pull request's purpose is to fix it.