### PR TITLE
docs: update references to sequence counters to consistently start counting from 0

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -71,6 +71,7 @@ The project has received contributions from (in alphabetical order):
 * Rob Zyskowski <zyskowski.rob@gmail.com>
 * Robrecht De Rouck <Robrecht.De.Rouck@gmail.com>
 * Samuel Paccoud <samuel@sampaccoud.com>
+* Sarah Boyce <sarahvboyce95@gmail.com>
 * Saul Shanabrook <s.shanabrook@gmail.com>
 * Sean Löfgren <SeanBE@users.noreply.github.com>
 * Shahriar Tajbakhsh <shahriar@metaview.ai>

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -99,10 +99,18 @@ This is achieved with the :class:`~factory.Sequence` declaration:
 
 .. code-block:: pycon
 
+    >>> # The sequence counter starts at 0 by default
     >>> UserFactory()
     <User: user0>
     >>> UserFactory()
     <User: user1>
+
+    >>> # A value can be provided for a sequence-driven field
+    >>> # but this still increments the sequence counter
+    >>> UserFactory(username="ada.lovelace")
+    <User: ada.lovelace>
+    >>> UserFactory()
+    <User: user3>
 
 .. note:: For more complex situations, you may also use the :meth:`~factory.@sequence` decorator (note that ``self`` is not added as first parameter):
 
@@ -116,6 +124,7 @@ This is achieved with the :class:`~factory.Sequence` declaration:
                 def username(n):
                     return 'user%d' % n
 
+    To set or reset the sequence counter see :ref:`Forcing a sequence counter <forcing-a-sequence-counter>`.
 
 LazyFunction
 ------------
@@ -165,7 +174,7 @@ taking the object being built and returning the value for the field:
 .. code-block:: pycon
 
     >>> UserFactory()
-    <User: user1 (user1@example.com)>
+    <User: user0 (user0@example.com)>
 
     >>> # The LazyAttribute handles overridden fields
     >>> UserFactory(username='john')
@@ -173,7 +182,7 @@ taking the object being built and returning the value for the field:
 
     >>> # They can be directly overridden as well
     >>> UserFactory(email='doe@example.com')
-    <User: user3 (doe@example.com)>
+    <User: user2 (doe@example.com)>
 
 
 .. note:: As for :class:`~factory.Sequence`, a :meth:`~factory.@lazy_attribute` decorator is available:

--- a/docs/orms.rst
+++ b/docs/orms.rst
@@ -476,9 +476,9 @@ A (very) simple example:
     >>> session.query(User).all()
     []
     >>> UserFactory()
-    <User: User 1>
+    <User: User 0>
     >>> session.query(User).all()
-    [<User: User 1>]
+    [<User: User 0>]
 
 
 Managing sessions

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -545,13 +545,13 @@ In order to get a dict, we'll just have to swap the model; the easiest way is to
         class Meta:
             model = models.User
 
-        first_name = factory.Sequence(lambda n: "Agent %03d" % n)
+        first_name = factory.Sequence(lambda n: "Agent %03d" % n)  # Agent 000, Agent 001, Agent 002
         username = factory.Faker('user_name')
 
 .. code-block:: pycon
 
     >>> factory.build(dict, FACTORY_CLASS=UserFactory)
-    {'first_name': "Agent 001", 'username': 'john_doe'}
+    {'first_name': "Agent 000", 'username': 'john_doe'}
 
 
 Fuzzying Django model field choices

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -956,10 +956,12 @@ This declaration takes a single argument, a function accepting a single paramete
 .. code-block:: pycon
 
     >>> UserFactory().phone
-    '123-555-0001'
+    '123-555-0000'
     >>> UserFactory().phone
-    '123-555-0002'
+    '123-555-0001'
 
+.. note:: The sequence counter starts at 0 and can be set or reset,
+          see :ref:`Forcing a sequence counter <forcing-a-sequence-counter>`.
 
 Decorator
 ~~~~~~~~~
@@ -985,9 +987,9 @@ be the sequence counter - this might be confusing:
 
 .. code-block:: pycon
 
-    >>> UserFactory().phone
+    >>> UserFactory().phone  # current sequence counter at 9999
     '000-555-9999'
-    >>> UserFactory().phone
+    >>> UserFactory().phone  # current sequence counter at 10000
     '001-555-0000'
 
 
@@ -1010,10 +1012,10 @@ The sequence counter is shared across all :class:`Sequence` attributes of the
 
     >>> u = UserFactory()
     >>> u.phone, u.office
-    '0041', 'A23-B041'
+    '0040', 'A23-B040'
     >>> u2 = UserFactory()
     >>> u2.phone, u2.office
-    '0042', 'A23-B042'
+    '0041', 'A23-B041'
 
 
 Inheritance
@@ -1039,16 +1041,17 @@ is shared across the :class:`Factory` classes:
 
     >>> u = UserFactory()
     >>> u.phone
-    '123-555-0001'
+    '123-555-0000'
 
     >>> e = EmployeeFactory()
     >>> e.phone, e.office_phone
-    '123-555-0002', '0002'
+    '123-555-0001', '0001'
 
     >>> u2 = UserFactory()
     >>> u2.phone
-    '123-555-0003'
+    '123-555-0002'
 
+.. _forcing-a-sequence-counter:
 
 Forcing a sequence counter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1107,9 +1110,9 @@ It takes a single argument, a function whose two parameters are, in order:
 .. code-block:: pycon
 
     >>> UserFactory().email
-    'john@s1.example.com'
+    'john@s0.example.com'
     >>> UserFactory(login='jack').email
-    'jack@s2.example.com'
+    'jack@s1.example.com'
 
 
 Decorator
@@ -1305,7 +1308,7 @@ That declaration takes a single argument, a dot-delimited path to the attribute 
         class Meta:
             model = User
 
-        birthdate = factory.Sequence(lambda n: datetime.date(2000, 1, 1) + datetime.timedelta(days=n))
+        birthdate = factory.fuzzy.FuzzyDate()
         birthmonth = factory.SelfAttribute('birthdate.month')
 
 .. code-block:: pycon


### PR DESCRIPTION
### Summary
The sequence counter starts from 0 but there are some instances in the docs that imply it starts from 1.
Updated these instances as suggested by this issue: https://github.com/FactoryBoy/factory_boy/issues/848

Tried to add some clarifying notes, please let me know if I've made things worse and not better, I won't be offended :smile: 
This is also my first contribution, happy to be pointed in a different direction on how to help if something else is more useful :+1: 