### PR TITLE
Set USE_TZ=True for the Django test project

### DIFF
--- a/tests/djapp/settings.py
+++ b/tests/djapp/settings.py
@@ -29,3 +29,7 @@ INSTALLED_APPS = [
 MIDDLEWARE_CLASSES = ()
 
 SECRET_KEY = 'testing.'
+
+# TODO: Will be the default after Django 5.0. Remove this setting when
+# Django 5.0 is the last supported version.
+USE_TZ = True


### PR DESCRIPTION
Django 5.0 will change the default from USE_TZ=False to USE_TZ=True.
https://docs.djangoproject.com/en/dev/ref/settings/#use-tz

Apply the default immediately to avoid the following deprecation warning
in Django 4.0+:

django.utils.deprecation.RemovedInDjango50Warning: The default value of
USE_TZ will change from False to True in Django 5.0. Set USE_TZ to False
in your project settings if you want to keep the current default
behavior.