### PR TITLE
Remove confusing return in post_generation example

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1891,7 +1891,6 @@ A decorator is also provided, decorating a single method accepting the same
                 return
             path = extracted or os.path.join('/tmp/mbox/', obj.login)
             os.path.makedirs(path)
-            return path
 
 .. OHAI_VIM**
 


### PR DESCRIPTION
The return value of post generation hooks is stored for advanced uses
(i.e. saving instances for DjangoModelFactory after the post generation
hooks completed), but this use is undocumented and not part of the
public API.

After issue #316 is completed, the save on post generation for
DjangoModelFactory will be removed. That will also drop the last use for
the `_after_postgeneration()` extension point. However, the extension
point is kept to avoid disruption for projects that may be relying on
it.

Closes #882