### PR TITLE
Allow to bypass declarations.Transformer

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -933,6 +933,19 @@ It expects two arguments:
    >>> UpperFactory(name="John").name
    'JOHN'
 
+Escape hatch
+~~~~~~~~~~~~
+
+In order to set a value verbatim on the generated object, wrap the value in a
+:class:`~factory.declarations.RawValue`.
+
+.. code-block:: pycon
+
+   >>> from factory import RawValue
+   >>> # Using RawValue(), the transform function is not applied.
+   >>> UpperFactory(name=RawValue("john")).name
+   'john'
+
 
 Sequence
 """"""""

--- a/factory/__init__.py
+++ b/factory/__init__.py
@@ -20,6 +20,7 @@ from .declarations import (
     Maybe,
     PostGeneration,
     PostGenerationMethodCall,
+    RawValue,
     RelatedFactory,
     RelatedFactoryList,
     SelfAttribute,

--- a/factory/builder.py
+++ b/factory/builder.py
@@ -156,12 +156,16 @@ def parse_declarations(decls, base_pre=None, base_post=None):
             # Set it as `key__`
             magic_key = post_declarations.join(k, '')
             extra_post[magic_key] = v
-        elif k in pre_declarations and isinstance(
-            pre_declarations[k].declaration, declarations.Transformer
-        ):
-            extra_maybenonpost[k] = pre_declarations[k].declaration.function(v)
         else:
-            extra_maybenonpost[k] = v
+            value = v
+            try:
+                pre_declaration = pre_declarations[k]
+            except KeyError:
+                pass
+            else:
+                if isinstance(pre_declaration.declaration, declarations.Transformer):
+                    value = pre_declaration.declaration.evaluate_extra(v)
+            extra_maybenonpost[k] = value
 
     # Start with adding new post-declarations
     post_declarations.update(extra_post)

--- a/factory/declarations.py
+++ b/factory/declarations.py
@@ -100,6 +100,11 @@ class LazyAttribute(BaseDeclaration):
         return self.function(instance)
 
 
+class RawValue:
+    def __init__(self, value):
+        self.value = value
+
+
 class Transformer(LazyFunction):
     """Transform value using given function.
 
@@ -114,6 +119,11 @@ class Transformer(LazyFunction):
 
     def evaluate(self, instance, step, extra):
         return self.function(self.value)
+
+    def evaluate_extra(self, maybe_raw_value):
+        if isinstance(maybe_raw_value, RawValue):
+            return maybe_raw_value.value
+        return self.function(maybe_raw_value)
 
 
 class _UNSPECIFIED:

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -2,7 +2,7 @@
 
 from unittest import TestCase
 
-from factory import Factory, Transformer
+from factory import Factory, RawValue, Transformer
 
 
 class TransformCounter:
@@ -44,3 +44,7 @@ class TransformerTest(TestCase):
     def test_transform_kwarg(self):
         self.assertEqual("TEST", UpperFactory(name="test").name)
         self.assertEqual(transform.calls_count, 1)
+
+    def test_transform_rawvalue(self):
+        self.assertEqual("lower", UpperFactory(name=RawValue("lower")).name)
+        self.assertEqual(transform.calls_count, 0)


### PR DESCRIPTION
Offer an escape hatch for users trying to pass a value directly for a
field that has a Transformer declaration.

Fixes #886