### PR TITLE
Drop support for EOL python 3.6, add support for python 3.10 and django 4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,19 +13,22 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 3.6
-          - 3.7
-          - 3.8
-          - 3.9
-          - pypy3
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "pypy-3.8"
         tox-environment:
-          - django22-alchemy-mongoengine
-          - django31-alchemy-mongoengine
           - django32-alchemy-mongoengine
+          - django40-alchemy-mongoengine
         include:
-          - python-version: 3.9
-            tox-environment: djangomain-alchemy-mongoengine
-
+          - python-version: "3.7"
+            tox-environment: django22-alchemy-mongoengine
+          - python-version: "pypy-3.7"
+            tox-environment: django22-alchemy-mongoengine
+          - python-version: "3.7"
+            tox-environment: django32-alchemy-mongoengine
+          - python-version: "pypy-3.7"
+            tox-environment: django32-alchemy-mongoengine
     services:
       mongodb:
         image: mongo

--- a/README.rst
+++ b/README.rst
@@ -401,7 +401,7 @@ To test with a specific framework version, you may use a ``tox`` target:
     $ tox --listenvs
 
     # run tests inside a specific environment
-    $ tox -e py36-django20-alchemy13-mongoengine017
+    $ tox -e py310-djangomain-alchemy-mongoengine
 
 Valid options are:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,8 @@ ChangeLog
     - :issue:`366`: Add :class:`factory.django.Password` to generate Django :class:`~django.contrib.auth.models.User`
       passwords.
     - Add support for Django 3.2
+    - Add support for Django 4.0
+    - Add support for Python 3.10
 
 *Bugfix:*
 
@@ -43,6 +45,8 @@ ChangeLog
 *Removed:*
 
     - Drop support for Django 3.0
+    - Drop support for Django 3.1
+    - Drop support for Python 3.6
 
 3.2.0 (2020-12-28)
 ------------------

--- a/examples/django_demo/django_demo/urls.py
+++ b/examples/django_demo/django_demo/urls.py
@@ -13,7 +13,11 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url
+try:
+    # TODO: After dropping Django 2.2, switch to `path`
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 from django.contrib import admin
 
 urlpatterns = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,18 +16,18 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Framework :: Django
     Framework :: Django :: 2.2
-    Framework :: Django :: 3.1
     Framework :: Django :: 3.2
+    Framework :: Django :: 4.0
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Software Development :: Testing
@@ -36,7 +36,7 @@ classifiers =
 [options]
 zip_safe = false
 packages = factory
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires = Faker>=0.7.0
 
 [options.extras_require]

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,10 @@
 minversion = 1.9
 envlist =
     lint
-    py{36,37,38,39,py3}-django22-alchemy-mongoengine
-    py{36,37,38,39,py3}-django31-alchemy-mongoengine
-    py{36,37,38,39,py3}-django32-alchemy-mongoengine
-    py39-djangomaster-alchemy-mongoengine
+    py{37,38,39,py3}-django22-alchemy-mongoengine
+    py{37,38,39,310,py3}-django32-alchemy-mongoengine
+    py{38,39,310,py3}-django40-alchemy-mongoengine
+    py310-djangomain-alchemy-mongoengine
     docs
     examples
     linkcheck
@@ -15,10 +15,10 @@ toxworkdir = {env:TOX_WORKDIR:.tox}
 [testenv]
 deps =
     django22: Django>=2.2,<2.3
-    django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
+    django40: Django>=4.0,<4.1
     djangomain: https://github.com/django/django/archive/main.tar.gz
-    django{22,31,32,main}: Pillow
+    django{22,32,40,main}: Pillow
     alchemy: SQLAlchemy
     mongoengine: mongoengine
 


### PR DESCRIPTION
In my other PR (#903) i would like to add some basic typing support for factory-boy, but it uses features unavailable for python 3.6, and i haven't found simple workarounds.

Python 3.6 has reached end of life, so maybe drop it, and add 3.10?

This also changes pypy, from just `pypy3`, which resolves as pypy-3.6, to `pypy-3.7` and `pypy-3.8`.

Quotes used for versions, becouse without them you cannot write `3.10`, yaml parses it as number 3.1.