### PR TITLE
Fix documentation build warning about extlinks

### DIFF
--- a/docs/fuzzy.rst
+++ b/docs/fuzzy.rst
@@ -6,8 +6,7 @@ Fuzzy attributes
 .. note:: Now that FactoryBoy includes the :class:`factory.Faker` class, most of
           these built-in fuzzers are deprecated in favor of their
           `Faker <https://faker.readthedocs.io/>`_ equivalents. Further
-          discussion here:
-          `<https://github.com/FactoryBoy/factory_boy/issues/271/>`_
+          discussion in :issue:`271`.
 
 Some tests may be interested in testing with fuzzy, random values.
 


### PR DESCRIPTION
Use extlinks Sphinx extension instead of directly linking to the GitHub
issue.