### PR TITLE
Specify uuidRepresentation for mongoengine

### DIFF
--- a/tests/test_mongoengine.py
+++ b/tests/test_mongoengine.py
@@ -57,6 +57,7 @@ class MongoEngineTestCase(unittest.TestCase):
             read_preference=mongo_rp.ReadPreference.PRIMARY,
             # PyMongo>=2.1 has a 20s timeout, use 100ms instead
             serverselectiontimeoutms=cls.server_timeout_ms,
+            uuidRepresentation='standard',
         )
 
     @classmethod


### PR DESCRIPTION
https://github.com/MongoEngine/mongoengine/blob/master/docs/changelog.rst#changes-in-0240:

> UUIDs are encoded with the pythonLegacy encoding by default instead of
  the newer and cross platform standard encoding. Existing UUIDs will
  need to be migrated before changing the encoding, and this should be
  done explicitly by the user rather than switching to a new default by
  MongoEngine. This default will change at a later date, but to allow
  specifying and then migrating to the new format a default json_options
  has been provided.