### PR TITLE
Include session getter support

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,8 @@ ChangeLog
 
     - :issue:`366`: Add :class:`factory.django.Password` to generate Django :class:`~django.contrib.auth.models.User`
       passwords.
+    - :issue:`304`: Add :attr:`~factory.alchemy.SQLAlchemyOptions.sqlalchemy_session_factory` to dynamically
+      create sessions for use by the :class:`~factory.alchemy.SQLAlchemyModelFactory`.
     - Add support for Django 3.2
     - Add support for Django 4.0
     - Add support for Python 3.10

--- a/docs/orms.rst
+++ b/docs/orms.rst
@@ -369,6 +369,25 @@ To work, this class needs an `SQLAlchemy`_ session object affected to the :attr:
         SQLAlchemy session to use to communicate with the database when creating
         an object through this :class:`SQLAlchemyModelFactory`.
 
+    .. attribute:: sqlalchemy_session_factory
+
+       .. versionadded:: 3.3.0
+
+         :class:`~collections.abc.Callable` returning a :class:`~sqlalchemy.orm.Session` instance to use to communicate
+         with the database. You can either provide the session through this attribute, or through
+         :attr:`~factory.alchemy.SQLAlchemyOptions.sqlalchemy_session`, but not both at the same time.
+
+        .. code-block:: python
+
+            from . import common
+
+            class UserFactory(factory.alchemy.SQLAlchemyModelFactory):
+                class Meta:
+                    model = User
+                    sqlalchemy_session_factory = lambda: common.Session()
+
+                username = 'john'
+
     .. attribute:: sqlalchemy_session_persistence
 
         Control the action taken by ``sqlalchemy_session`` at the end of a create call.

--- a/tests/test_alchemy.py
+++ b/tests/test_alchemy.py
@@ -264,6 +264,34 @@ class SQLAlchemyNoSessionTestCase(unittest.TestCase):
         self.assertEqual(inst1.id, 1)
 
 
+class SQLAlchemySessionFactoryTestCase(unittest.TestCase):
+
+    def test_create_get_session_from_sqlalchemy_session_factory(self):
+        class SessionGetterFactory(SQLAlchemyModelFactory):
+            class Meta:
+                model = models.StandardModel
+                sqlalchemy_session = None
+                sqlalchemy_session_factory = lambda: models.session
+
+            id = factory.Sequence(lambda n: n)
+
+        SessionGetterFactory.create()
+        self.assertEqual(SessionGetterFactory._meta.sqlalchemy_session, models.session)
+        # Reuse the session obtained from sqlalchemy_session_factory.
+        SessionGetterFactory.create()
+
+    def test_create_raise_exception_sqlalchemy_session_factory_not_callable(self):
+        message = "^Provide either a sqlalchemy_session or a sqlalchemy_session_factory, not both$"
+        with self.assertRaisesRegex(RuntimeError, message):
+            class SessionAndGetterFactory(SQLAlchemyModelFactory):
+                class Meta:
+                    model = models.StandardModel
+                    sqlalchemy_session = models.session
+                    sqlalchemy_session_factory = lambda: models.session
+
+                id = factory.Sequence(lambda n: n)
+
+
 class NameConflictTests(unittest.TestCase):
     """Regression test for `TypeError: _save() got multiple values for argument 'session'`
 


### PR DESCRIPTION
As our team tries to migrate our tests to use factory_boy, we found tricky to set the DB sessions during the tests runtime, mocking was tricky and nasty. I [found this issue](https://github.com/FactoryBoy/factory_boy/issues/304), which closely resemble the problem we are currently facing, and decided to give a shot.

The idea is to allow passing a callable returning the SQLAlchemy session in a Meta attribute called `sqlalchemy_session_factory`. This has several use-cases, allowing control of the session on runtime.

This is my first OSS contribution ever, super excited with it. Any feedback is appreciated :) 

Fixes https://github.com/FactoryBoy/factory_boy/issues/304
