### PR TITLE
Docs: Import factory after mangling sys.path

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,13 +9,13 @@
 import os
 import sys
 
-import factory
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.dirname(os.path.abspath('.')))
 
+# Must be imported after the parent directory was added to sys.path for global sphinx installation.
+import factory  # noqa
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
Sphinx conf.py mangles sys.path to add the top-level directory, so that
factory_boy is available. Don’t import the package before the path has
been updated.

Refs #929