### PR TITLE
Clear SQLAlchemy tables after each test

### DIFF
--- a/tests/alchemyapp/models.py
+++ b/tests/alchemyapp/models.py
@@ -48,6 +48,3 @@ class SpecialFieldModel(Base):
 
     id = Column(Integer(), primary_key=True)
     session = Column(Unicode(20))
-
-
-Base.metadata.create_all(engine)

--- a/tests/test_alchemy.py
+++ b/tests/test_alchemy.py
@@ -73,8 +73,12 @@ class WithMultipleGetOrCreateFieldsFactory(SQLAlchemyModelFactory):
 
 
 class TransactionTestCase(unittest.TestCase):
+    def setUp(self):
+        models.Base.metadata.create_all(models.engine)
+
     def tearDown(self):
         models.session.rollback()
+        models.Base.metadata.drop_all(models.engine)
 
 
 class SQLAlchemyPkSequenceTestCase(TransactionTestCase):


### PR DESCRIPTION
Not as efficient as wrapping the test in a transaction, but allows to
reset sequences and remove all table data, so that each test starts from
a clean slate.