### PR TITLE
Drop unused directive TOX_WORKDIR

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,6 @@ envlist =
     py{38,39,310,py38}-django40-mongo-alchemy-{sqlite,postgres}
     py310-djangomain-mongo-alchemy-{sqlite,postgres}
 
-toxworkdir = {env:TOX_WORKDIR:.tox}
-
 [gh-actions]
 python =
     3.7: py37


### PR DESCRIPTION
The directive is spelled TOX_WORK_DIR, so it is ineffective. Also,
using `.tox` is the default.