### PR TITLE
Improve SQLAlchemy tests session cleanup

### DIFF
--- a/tests/test_alchemy.py
+++ b/tests/test_alchemy.py
@@ -93,7 +93,7 @@ class TransactionTestCase(unittest.TestCase):
         models.Base.metadata.create_all(models.engine)
 
     def tearDown(self):
-        models.session.rollback()
+        models.session.remove()
         models.Base.metadata.drop_all(models.engine)
 
 


### PR DESCRIPTION
The remove method rolls back the transaction, but also releases
associated objects.

https://docs.sqlalchemy.org/en/14/orm/contextual.html#sqlalchemy.orm.scoping.scoped_session.remove