### PR TITLE
Add sqlalchemy_utils as a development dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ dev =
     isort
     Pillow
     SQLAlchemy
+    sqlalchemy_utils
     mongoengine
     wheel>=0.32.0
     tox


### PR DESCRIPTION
Missed in 05e7d9690737444b8a56c24d7e15d2f3af89937b.