### PR TITLE
Move coverage metadata to setup.cfg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,9 +82,9 @@ lint:
 
 coverage:
 	$(COVERAGE) erase
-	$(COVERAGE) run "--include=$(PACKAGE)/*.py,$(TESTS_DIR)/*.py" --branch -m unittest
-	$(COVERAGE) report "--include=$(PACKAGE)/*.py,$(TESTS_DIR)/*.py"
-	$(COVERAGE) html "--include=$(PACKAGE)/*.py,$(TESTS_DIR)/*.py"
+	$(COVERAGE) run --branch -m unittest
+	$(COVERAGE) report
+	$(COVERAGE) html
 
 
 .PHONY: test testall example-test lint coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,3 +81,8 @@ include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True
 line_length = 88
+
+[coverage:report]
+include=
+    factory/*.py
+    tests/*.py


### PR DESCRIPTION
Avoids repeating across coverage invocations.