### PR TITLE
Use unittest test discovery for coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ lint:
 
 coverage:
 	$(COVERAGE) erase
-	$(COVERAGE) run "--include=$(PACKAGE)/*.py,$(TESTS_DIR)/*.py" --branch $(SETUP_PY) test
+	$(COVERAGE) run "--include=$(PACKAGE)/*.py,$(TESTS_DIR)/*.py" --branch -m unittest
 	$(COVERAGE) report "--include=$(PACKAGE)/*.py,$(TESTS_DIR)/*.py"
 	$(COVERAGE) html "--include=$(PACKAGE)/*.py,$(TESTS_DIR)/*.py"
 


### PR DESCRIPTION
Missed in 239bdeac12fba5b0abb3599be3165d91343923ef.