### PR TITLE
Enable coverage context collection

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,13 @@ force_grid_wrap = 0
 use_parentheses = True
 line_length = 88
 
+[coverage:run]
+dynamic_context = test_function
+
 [coverage:report]
 include=
     factory/*.py
     tests/*.py
+
+[coverage:html]
+show_contexts = True


### PR DESCRIPTION
Annotates coverage lines with the test functions that cover them.