### PR TITLE
Add support for a `coerce` function for `factory.SelfAttribute`

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -64,6 +64,7 @@ The project has received contributions from (in alphabetical order):
 * Omer <omer@stokeet.com>
 * Pauly Fenwar <fenney@gmail.com>
 * Peter Marsh <pete@skimlinks.com>
+* Petter Friberg <petter_friberg@hotmail.com> (https://github.com/flaeppe)
 * Puneeth Chaganti <punchagan@muse-amuse.in>
 * QuantumGhost <obelisk.reg+github@gmail.com>
 * Raphaël Barrois <raphael.barrois+fboy@polytechnique.org> (https://github.com/rbarrois)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,8 @@ ChangeLog
     - Add support for Django 3.2
     - Add support for Django 4.0
     - Add support for Python 3.10
+    - :issue:`963`: Add a ``coerce`` argument to :class:`~factory.SelfAttribute`
+    - Add documentation for ``default`` argument of :class:`~factory.SelfAttribute`
 
 *Bugfix:*
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1295,12 +1295,23 @@ Obviously, such circular relationships require careful handling of loops:
 SelfAttribute
 """""""""""""
 
-.. class:: SelfAttribute(dotted_path_to_attribute)
+.. class:: SelfAttribute(dotted_path_to_attribute, default=, coerce=None)
 
-Some fields should reference another field of the object being constructed, or an attribute thereof.
+    Some fields should reference another field of the object being constructed,
+    or an attribute thereof.
 
-This is performed by the :class:`~factory.SelfAttribute` declaration.
-That declaration takes a single argument, a dot-delimited path to the attribute to fetch:
+    This is performed by the :class:`~factory.SelfAttribute` declaration.
+    The declaration requires a dot-delimited path to the attribute to fetch.
+
+    .. attribute:: default
+
+        A default value to use if the specified attribute doesn't exist.
+
+    .. attribute:: coerce
+
+        A function that takes one argument and returns a coerced value.
+        Note that coercion will also happen on a default value.
+
 
 .. code-block:: python
 
@@ -1318,6 +1329,52 @@ That declaration takes a single argument, a dot-delimited path to the attribute 
     date(2000, 3, 15)
     >>> u.birthmonth
     3
+
+
+.. _selfattribute-default:
+
+Default
+~~~~~~~
+
+.. code-block:: python
+
+   class UserFactory(factory.Factory):
+      class Meta:
+          model = User
+
+      name = factory.SelfAttribute('missing_attr', default="John Smith")
+
+.. code-block:: pycon
+
+   >>> u = UserFactory()
+   >>> u.name
+   'John Smith'
+
+
+.. _selfattribute-coerce:
+
+Coerce
+~~~~~~
+
+If the value of a referenced attribute needs to be changed, use the ``coerce`` parameter:
+
+.. code-block:: python
+
+   class UserFactory(factory.Factory):
+      class Meta:
+          model = User
+
+      last_login = factory.fuzzy.FuzzyDateTime(datetime.datetime(2022, 1, 1, tzinfo=UTC))
+      is_active = factory.SelfAttribute("last_login", coerce=bool)
+
+.. code-block:: pycon
+
+   >>> u = UserFactory()
+   >>> u.is_active
+   True
+   >>> u = UserFactory(last_login=None)
+   >>> u.is_active
+   False
 
 
 .. _factory-parent:

--- a/tests/test_declarations.py
+++ b/tests/test_declarations.py
@@ -56,30 +56,42 @@ class SelfAttributeTestCase(unittest.TestCase):
         self.assertEqual(0, a.depth)
         self.assertEqual('foo.bar.baz', a.attribute_name)
         self.assertEqual(declarations._UNSPECIFIED, a.default)
+        self.assertIsNone(a.coerce)
 
     def test_dot(self):
         a = declarations.SelfAttribute('.bar.baz')
         self.assertEqual(1, a.depth)
         self.assertEqual('bar.baz', a.attribute_name)
         self.assertEqual(declarations._UNSPECIFIED, a.default)
+        self.assertIsNone(a.coerce)
 
     def test_default(self):
         a = declarations.SelfAttribute('bar.baz', 42)
         self.assertEqual(0, a.depth)
         self.assertEqual('bar.baz', a.attribute_name)
         self.assertEqual(42, a.default)
+        self.assertIsNone(a.coerce)
 
     def test_parent(self):
         a = declarations.SelfAttribute('..bar.baz')
         self.assertEqual(2, a.depth)
         self.assertEqual('bar.baz', a.attribute_name)
         self.assertEqual(declarations._UNSPECIFIED, a.default)
+        self.assertIsNone(a.coerce)
 
     def test_grandparent(self):
         a = declarations.SelfAttribute('...bar.baz')
         self.assertEqual(3, a.depth)
         self.assertEqual('bar.baz', a.attribute_name)
         self.assertEqual(declarations._UNSPECIFIED, a.default)
+        self.assertIsNone(a.coerce)
+
+    def test_sets_coerce(self):
+        a = declarations.SelfAttribute('foo', coerce=str)
+        self.assertEqual(0, a.depth)
+        self.assertEqual('foo', a.attribute_name)
+        self.assertEqual(declarations._UNSPECIFIED, a.default)
+        self.assertIs(str, a.coerce)
 
 
 class IteratorTestCase(unittest.TestCase):

--- a/tests/test_using.py
+++ b/tests/test_using.py
@@ -567,6 +567,35 @@ class UsingFactoryTestCase(unittest.TestCase):
         test_model = TestModel2Factory()
         self.assertEqual(4, test_model.two.three)
 
+    def test_self_attribute_calls_coercion(self):
+        coerced = False
+
+        def to_str(value):
+            nonlocal coerced
+            coerced = True
+            return str(value)
+
+        class TestObjectFactory(factory.Factory):
+            class Meta:
+                model = TestObject
+
+            one = 1
+            two = factory.SelfAttribute('one', coerce=to_str)
+
+        instance = TestObjectFactory()
+        self.assertEqual("1", instance.two)
+        self.assertIs(coerced, True)
+
+    def test_self_attribute_coerces_default_value(self):
+        class TestObjectFactory(factory.Factory):
+            class Meta:
+                model = TestObject
+
+            one = factory.SelfAttribute("unknown", default=1, coerce=str)
+
+        instance = TestObjectFactory()
+        self.assertEqual("1", instance.one)
+
     def test_sequence_decorator(self):
         class TestObjectFactory(factory.Factory):
             class Meta:


### PR DESCRIPTION
`SelfAttribute` will, if given, call and return the return value of the `coerce` function

Closes: #963 