### PR TITLE
Remove Python 2 warning

### DIFF
--- a/docs/fuzzy.rst
+++ b/docs/fuzzy.rst
@@ -75,15 +75,6 @@ FuzzyChoice
               This allows passing in, for instance, a Django queryset that will
               only hit the database during the database, not at import time.
 
-    .. warning:: When using Python2 and list comprehension, use private variable
-                 names as in:
-
-                 `[_x.name for _x in items]`
-
-                 instead of:
-
-                 `[x.name for x in items]`
-
     .. attribute:: choices
 
         The list of choices to select randomly


### PR DESCRIPTION
Support for Python 2 was dropped as part of the `3.0.0` release back in
2020. So this no longer applies.