### PR TITLE
Stop throwing custom `ImportError`

### DIFF
--- a/examples/django_demo/manage.py
+++ b/examples/django_demo/manage.py
@@ -4,19 +4,5 @@ import sys
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "django_demo.settings")
-    try:
-        from django.core.management import execute_from_command_line
-    except ImportError:
-        # The above import may fail for some other reason. Ensure that the
-        # issue is really that Django is missing to avoid masking other
-        # exceptions on Python 2.
-        try:
-            import django  # noqa: F401
-        except ImportError:
-            raise ImportError(
-                "Couldn't import Django. Are you sure it's installed and "
-                "available on your PYTHONPATH environment variable? Did you "
-                "forget to activate a virtual environment?"
-            )
-        raise
+    from django.core.management import execute_from_command_line
     execute_from_command_line(sys.argv)


### PR DESCRIPTION
This was necessary under python 2, but now that python 3 supports exception chaining, the underlying `ImportError` won't be masked by the other exceptions.

I considered augmenting the error message to mention checking in the path / venv, but these days I think people will naturally google for `ImportError` and find plenty of helpful context from StackOverflow etc.

Such as this very question/answer:
https://stackoverflow.com/questions/14013728/django-no-module-named-django-core-management