### PR TITLE
Use `importlib_metadata` to read version

### DIFF
--- a/factory/__init__.py
+++ b/factory/__init__.py
@@ -72,10 +72,8 @@ except ImportError:
 __author__ = 'Raphaël Barrois <raphael.barrois+fboy@polytechnique.org>'
 try:
     # Python 3.8+
-    from importlib.metadata import version
-
-    __version__ = version("factory_boy")
+    import importlib.metadata as importlib_metadata
 except ImportError:
-    import pkg_resources
+    import importlib_metadata
 
-    __version__ = pkg_resources.get_distribution("factory_boy").version
+__version__ = importlib_metadata.version("factory_boy")

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,9 @@ classifiers =
 zip_safe = false
 packages = factory
 python_requires = >=3.7
-install_requires = Faker>=0.7.0
+install_requires =
+    Faker>=0.7.0
+    importlib_metadata;python_version<"3.8"
 
 [options.extras_require]
 dev =

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,10 @@
+# Copyright: See the LICENSE file.
+
+import unittest
+
+import factory
+
+
+class VersionTestCase(unittest.TestCase):
+    def test_version(self):
+        self.assertEqual(factory.__version__, "3.2.1.dev0")


### PR DESCRIPTION
This fixes a bug where the `factory` could not be imported on Python 3.7 if `setuptools` wasn't installed (see below). Rather than require `setuptools` move to using `import-metadata` so that the same approach is used for Python < 3.8 and Python >= 3.8 (where `importlib.metadata` is available in the stdlib)

The bug: installing this distribution without `setuptools` results in an `ImportError` when trying to determine the distribution's version (only on Python<3.8, above this it uses the builtin `importlib.metadata`):

    $ python --version
    Python 3.7.4
    $ python -m venv .venv
    $ source .venv/bin/activate
    $ pip uninstall --yes --quiet setuptools
    $ pip install --quiet factory-boy
    $ python -c 'import factory'
    Traceback (most recent call last):
      File "/tmp/tmp.qEc9M3LwV5/.venv/lib/python3.7/site-packages/factory/__init__.py", line 74, in <module>
        from importlib.metadata import version
    ModuleNotFoundError: No module named 'importlib.metadata'

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/tmp.qEc9M3LwV5/.venv/lib/python3.7/site-packages/factory/__init__.py", line 78, in <module>
        import pkg_resources
    ModuleNotFoundError: No module named 'pkg_resources'

Fixes #990

I've added a test mostly just out of habit, but it comes at the price of having to be updated each time the version changes so it might be more hassle than it's worth.