### PR TITLE
Remove locale as required extra for Faker.evaluate

### DIFF
--- a/factory/faker.py
+++ b/factory/faker.py
@@ -43,7 +43,7 @@ class Faker(declarations.BaseDeclaration):
             **kwargs)
 
     def evaluate(self, instance, step, extra):
-        locale = extra.pop('locale')
+        locale = extra.pop('locale', None)
         subfaker = self._get_faker(locale)
         return subfaker.format(self.provider, **extra)
 

--- a/tests/test_faker.py
+++ b/tests/test_faker.py
@@ -50,7 +50,7 @@ class FakerTests(unittest.TestCase):
     def test_simple_biased(self):
         self._setup_mock_faker(name="John Doe")
         faker_field = factory.Faker('name')
-        self.assertEqual("John Doe", faker_field.evaluate(None, None, {'locale': None}))
+        self.assertEqual("John Doe", faker_field.evaluate(None, None, {}))
 
     def test_full_factory(self):
         class Profile:


### PR DESCRIPTION
By virtue of `.pop` not defaulting to `None`, `locale` is a required `extra` kwarg for `Faker.evaluate`

If we consider that `Faker.__init__` doesn't take `locale` as a required extra key, it also makes sense to follow this behavior for `evaluate`. see `factory/faker.py:L39`

**Use case:**
Currently, if we want to utilize fake (outside of the Factory class context), the following code is used:

```
from factory import faker

name_faker = faker.Faker("name")
name_faker.evaluate(None, None, {"locale": None})
```
whereas it would be easier to just use:

```
name_faker.evaluate(None, None, {})
```
or even better if we could make the other params not required (out of scope fore this PR)
```
name_faker.evaluate()
```


this issue also seems to be reported here: https://github.com/FactoryBoy/factory_boy/issues/965
