### PR TITLE
Fixes Tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ setenv =
     py: DJANGO_SETTINGS_MODULE=tests.djapp.settings
     postgres: DJANGO_SETTINGS_MODULE=tests.djapp.settings_pg
 
-whitelist_externals = make
+allowlist_externals = make
 commands = make test
 
 [testenv:docs]


### PR DESCRIPTION
https://tox.wiki/en/latest/changelog.html#deprecations-and-removals-4-0-0rc4

`whitelist_externals` -> `allowlist_externals`


https://github.com/FactoryBoy/factory_boy/actions/runs/4105486224/jobs/7082408580 (this might expire after a day..)
```
docs: commands[0]> make doc spelling
[24](https://github.com/FactoryBoy/factory_boy/actions/runs/4105486224/jobs/7082408580#step:5:25)
docs: failed with make is not allowed, use allowlist_externals to allow it
[25](https://github.com/FactoryBoy/factory_boy/actions/runs/4105486224/jobs/7082408580#step:5:26)
.pkg: _exit> python /opt/hostedtoolcache/Python/3.11.1/x64/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
```