### PR TITLE
Fix mute signals for factories with post_generation hooks

### DIFF
--- a/factory/django.py
+++ b/factory/django.py
@@ -327,6 +327,9 @@ class mute_signals:
             # Retrieve __func__, the *actual* callable object.
             callable_obj._create = self.wrap_method(callable_obj._create.__func__)
             callable_obj._generate = self.wrap_method(callable_obj._generate.__func__)
+            callable_obj._after_postgeneration = self.wrap_method(
+                callable_obj._after_postgeneration.__func__
+            )
             return callable_obj
 
         else:

--- a/tests/djapp/models.py
+++ b/tests/djapp/models.py
@@ -18,10 +18,6 @@ class StandardModel(models.Model):
     foo = models.CharField(max_length=20)
 
 
-class WithRelation(models.Model):
-    rel = models.ForeignKey(StandardModel, models.CASCADE)
-
-
 class NonIntegerPk(models.Model):
     foo = models.CharField(max_length=20, primary_key=True)
     bar = models.CharField(max_length=20, blank=True)

--- a/tests/djapp/models.py
+++ b/tests/djapp/models.py
@@ -18,6 +18,10 @@ class StandardModel(models.Model):
     foo = models.CharField(max_length=20)
 
 
+class WithRelation(models.Model):
+    rel = models.ForeignKey(StandardModel, models.CASCADE)
+
+
 class NonIntegerPk(models.Model):
     foo = models.CharField(max_length=20, primary_key=True)
     bar = models.CharField(max_length=20, blank=True)

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -998,25 +998,25 @@ class PreventSignalsTestCase(django_test.TestCase):
         """
 
         @factory.django.mute_signals(signals.post_save)
-        class StandardFactory(factory.django.DjangoModelFactory):
+        class PointedFactory(factory.django.DjangoModelFactory):
             class Meta:
-                model = models.StandardModel
+                model = models.PointedModel
 
             @factory.post_generation
             def post_action(obj, create, extracted, **kwargs):
                 pass
 
-        class WithRelationFactory(factory.django.DjangoModelFactory):
-            rel = factory.SubFactory(StandardFactory)
+        class PointerFactory(factory.django.DjangoModelFactory):
+            pointed = factory.SubFactory(PointedFactory)
 
             class Meta:
-                model = models.WithRelation
+                model = models.PointerModel
 
-        WithRelationFactory.create()
+        PointerFactory.create()
 
         self.handlers.post_save.assert_called_once_with(
             signal=mock.ANY,
-            sender=models.WithRelation,
+            sender=models.PointerModel,
             instance=mock.ANY,
             created=True,
             update_fields=None,

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -1014,8 +1014,15 @@ class PreventSignalsTestCase(django_test.TestCase):
 
         WithRelationFactory.create()
 
-        # Called only once for WithRelationFactory.
-        self.handlers.post_save.assert_called_once()
+        self.handlers.post_save.assert_called_once_with(
+            signal=mock.ANY,
+            sender=models.WithRelation,
+            instance=mock.ANY,
+            created=True,
+            update_fields=None,
+            raw=False,
+            using="default",
+        )
 
     def test_class_decorator_build(self):
         @factory.django.mute_signals(signals.pre_save, signals.post_save)


### PR DESCRIPTION
In my factories `mute_signals` was not working.

I investigated the issue and found out that there's another `save` inside `_after_postgeneration` method.

This PR fixes issue.