### PR TITLE
do not require 'locale' in Faker.evaluate

### DIFF
--- a/factory/faker.py
+++ b/factory/faker.py
@@ -43,7 +43,7 @@ class Faker(declarations.BaseDeclaration):
             **kwargs)
 
     def evaluate(self, instance, step, extra):
-        locale = extra.pop('locale')
+        locale = extra.pop('locale', None)
         subfaker = self._get_faker(locale)
         return subfaker.format(self.provider, **extra)
 


### PR DESCRIPTION
This fixes a `object has no attribute 'pop'` when using stubs

Fixes #965