### PR TITLE
fix: fix issue #965, use default when getting Faker locale

### DIFF
--- a/factory/declarations.py
+++ b/factory/declarations.py
@@ -490,7 +490,7 @@ class Maybe(BaseDeclaration):
             return target
 
     def evaluate_pre(self, instance, step, overrides):
-        choice = self.decider.evaluate(instance=instance, step=step, extra={})
+        choice = self.decider.evaluate_pre(instance=instance, step=step, overrides={})
         target = self.yes if choice else self.no
 
         if isinstance(target, BaseDeclaration):

--- a/factory/faker.py
+++ b/factory/faker.py
@@ -43,7 +43,7 @@ class Faker(declarations.BaseDeclaration):
             **kwargs)
 
     def evaluate(self, instance, step, extra):
-        locale = extra.pop('locale', None)
+        locale = extra.pop('locale')
         subfaker = self._get_faker(locale)
         return subfaker.format(self.provider, **extra)
 

--- a/factory/faker.py
+++ b/factory/faker.py
@@ -43,7 +43,7 @@ class Faker(declarations.BaseDeclaration):
             **kwargs)
 
     def evaluate(self, instance, step, extra):
-        locale = extra.pop('locale')
+        locale = extra.pop('locale', None)
         subfaker = self._get_faker(locale)
         return subfaker.format(self.provider, **extra)
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -51,3 +51,24 @@ class FakerRegressionTests(unittest.TestCase):
 
         unknown_author = AuthorFactory(unknown=True)
         self.assertEqual("", unknown_author.fullname)
+
+    def test_locale_issue_in_evaluate(self):
+        """Regression test for `KeyError: 'locale'` raised in `evaluate`.
+
+        See #965
+
+        """
+        class AuthorFactory(factory.Factory):
+            fullname = factory.Faker("name")
+            pseudonym = factory.Maybe(
+                decider=factory.Faker("pybool"),
+                yes_declaration=factory.Faker("username"),
+                no_declaration="",
+            )
+
+            class Meta:
+                model = Author
+
+        author = AuthorFactory()
+
+        self.assertIsInstance(author.pseudonym, str)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -52,7 +52,7 @@ class FakerRegressionTests(unittest.TestCase):
         unknown_author = AuthorFactory(unknown=True)
         self.assertEqual("", unknown_author.fullname)
 
-    def test_locale_issue_in_evaluate(self):
+    def test_evaluated_without_locale(self):
         """Regression test for `KeyError: 'locale'` raised in `evaluate`.
 
         See #965
@@ -62,8 +62,8 @@ class FakerRegressionTests(unittest.TestCase):
             fullname = factory.Faker("name")
             pseudonym = factory.Maybe(
                 decider=factory.Faker("pybool"),
-                yes_declaration=factory.Faker("username"),
-                no_declaration="",
+                yes_declaration="yes",
+                no_declaration="no",
             )
 
             class Meta:
@@ -71,4 +71,4 @@ class FakerRegressionTests(unittest.TestCase):
 
         author = AuthorFactory()
 
-        self.assertIsInstance(author.pseudonym, str)
+        self.assertIn(author.pseudonym, ["yes", "no"])


### PR DESCRIPTION
<details><summary>Output of a new regression test failure on master branch</summary>
<p>

```
ERROR: test_locale_issue_in_evaluate (tests.test_regression.FakerRegressionTests)
Regression test for `KeyError: 'locale'` raised in `evaluate`.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/skarzi/dev/github/factory_boy/tests/test_regression.py", line 72, in test_locale_issue_in_evaluate
    author = AuthorFactory()
  File "/Users/skarzi/dev/github/factory_boy/factory/base.py", line 40, in __call__
    return cls.create(**kwargs)
  File "/Users/skarzi/dev/github/factory_boy/factory/base.py", line 528, in create
    return cls._generate(enums.CREATE_STRATEGY, kwargs)
  File "/Users/skarzi/dev/github/factory_boy/factory/base.py", line 465, in _generate
    return step.build()
  File "/Users/skarzi/dev/github/factory_boy/factory/builder.py", line 260, in build
    step.resolve(pre)
  File "/Users/skarzi/dev/github/factory_boy/factory/builder.py", line 201, in resolve
    self.attributes[field_name] = getattr(self.stub, field_name)
  File "/Users/skarzi/dev/github/factory_boy/factory/builder.py", line 346, in __getattr__
    value = value.evaluate_pre(
  File "/Users/skarzi/dev/github/factory_boy/factory/declarations.py", line 493, in evaluate_pre
    choice = self.decider.evaluate(instance=instance, step=step, extra={})
  File "/Users/skarzi/dev/github/factory_boy/factory/faker.py", line 46, in evaluate
    locale = extra.pop('locale')
KeyError: 'locale'
```

</p>
</details> 

Fixes #965 