### PR TITLE
Transformer improvements

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -907,21 +907,22 @@ return value of the method:
 Transformer
 """""""""""
 
-.. class:: Transformer(transform, value)
+.. class:: Transformer(default_value, *, transform)
 
 A :class:`Transformer` applies a ``transform`` function to the provided value
 before to set the transformed value on the generated object.
 
-It expects two arguments:
+It expects one positional argument and one keyword argument:
 
-- ``transform``: function taking the value as parameter and returning the
+- ``default_value``: the default value, which passes through the ``transform``
+  function.
+- ``transform``: a function taking the value as parameter and returning the
   transformed value,
-- ``value``: the default value.
 
 .. code-block:: python
 
-   class UpperFactory(Factory):
-       name = Transformer(lambda x: x.upper(), "Joe")
+   class UpperFactory(factory.Factory):
+       name = factory.Transformer("Joe", transform=str.upper)
 
        class Meta:
            model = Upper

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -934,6 +934,14 @@ It expects one positional argument and one keyword argument:
    >>> UpperFactory(name="John").name
    'JOHN'
 
+Disabling
+~~~~~~~~~
+To disable a :class:`Transformer`, wrap the value in ``Transformer.Force``:
+
+.. code-block:: pycon
+
+   >>> UpperFactory(name=factory.Transformer.Force("John")).name
+   'John'
 
 Sequence
 """"""""

--- a/factory/builder.py
+++ b/factory/builder.py
@@ -2,7 +2,7 @@
 
 import collections
 
-from . import declarations, enums, errors, utils
+from . import enums, errors, utils
 
 DeclarationWithContext = collections.namedtuple(
     'DeclarationWithContext',
@@ -134,6 +134,14 @@ class DeclarationSet:
         return '<DeclarationSet: %r>' % self.as_dict()
 
 
+def _captures_overrides(declaration_with_context):
+    declaration = declaration_with_context.declaration
+    if enums.get_builder_phase(declaration) == enums.BuilderPhase.ATTRIBUTE_RESOLUTION:
+        return declaration.CAPTURE_OVERRIDES
+    else:
+        return False
+
+
 def parse_declarations(decls, base_pre=None, base_post=None):
     pre_declarations = base_pre.copy() if base_pre else DeclarationSet()
     post_declarations = base_post.copy() if base_post else DeclarationSet()
@@ -169,10 +177,12 @@ def parse_declarations(decls, base_pre=None, base_post=None):
     for k, v in extra_maybenonpost.items():
         if k in post_overrides:
             extra_post_declarations[k] = v
-        elif k in pre_declarations and isinstance(pre_declarations[k].declaration, declarations.Transformer):
-            declaration_with_context = pre_declarations[k]
-            transformer_decl = declaration_with_context.declaration
-            extra_pre_declarations[k] = transformer_decl.override_declaration(v)
+        elif k in pre_declarations and _captures_overrides(pre_declarations[k]):
+            # Send the overriding value to the existing declaration.
+            # By symmetry with the behaviour of PostGenerationDeclaration,
+            # we send it as `key__` -- i.e under the '' key.
+            magic_key = pre_declarations.join(k, '')
+            extra_pre_declarations[magic_key] = v
         else:
             # Anything else is pre_declarations
             extra_pre_declarations[k] = v

--- a/factory/builder.py
+++ b/factory/builder.py
@@ -156,10 +156,6 @@ def parse_declarations(decls, base_pre=None, base_post=None):
             # Set it as `key__`
             magic_key = post_declarations.join(k, '')
             extra_post[magic_key] = v
-        elif k in pre_declarations and isinstance(
-            pre_declarations[k].declaration, declarations.Transformer
-        ):
-            extra_maybenonpost[k] = pre_declarations[k].declaration.function(v)
         else:
             extra_maybenonpost[k] = v
 
@@ -173,6 +169,10 @@ def parse_declarations(decls, base_pre=None, base_post=None):
     for k, v in extra_maybenonpost.items():
         if k in post_overrides:
             extra_post_declarations[k] = v
+        elif k in pre_declarations and isinstance(pre_declarations[k].declaration, declarations.Transformer):
+            declaration_with_context = pre_declarations[k]
+            transformer_decl = declaration_with_context.declaration
+            extra_pre_declarations[k] = transformer_decl.override_declaration(v)
         else:
             # Anything else is pre_declarations
             extra_pre_declarations[k] = v

--- a/factory/django.py
+++ b/factory/django.py
@@ -192,8 +192,8 @@ class DjangoModelFactory(base.Factory):
 
 
 class Password(declarations.Transformer):
-    def __init__(self, password, *args, **kwargs):
-        super().__init__(make_password, password, *args, **kwargs)
+    def __init__(self, password, transform=make_password, **kwargs):
+        super().__init__(password, transform=transform, **kwargs)
 
 
 class FileField(declarations.BaseDeclaration):

--- a/tests/test_declarations.py
+++ b/tests/test_declarations.py
@@ -134,7 +134,7 @@ class IteratorTestCase(unittest.TestCase):
 
 class TransformerTestCase(unittest.TestCase):
     def test_transform(self):
-        t = declarations.Transformer(lambda x: x.upper(), 'foo')
+        t = declarations.Transformer('foo', transform=str.upper)
         self.assertEqual("FOO", utils.evaluate_declaration(t))
 
 

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -22,8 +22,9 @@ transform = TransformCounter()
 
 
 class Upper:
-    def __init__(self, name):
+    def __init__(self, name, **extra):
         self.name = name
+        self.extra = extra
 
 
 class UpperFactory(factory.Factory):
@@ -51,6 +52,13 @@ class TransformerTest(TestCase):
         value = UpperFactory(name=factory.Faker("first_name_female", locale="fr")).name
         self.assertIs(value.isupper(), True)
 
+    def test_transform_linked(self):
+        value = UpperFactory(
+            name=factory.LazyAttribute(lambda o: o.username.replace(".", " ")),
+            username="john.doe",
+        ).name
+        self.assertEqual(value, "JOHN DOE")
+
     def test_force_value(self):
         value = UpperFactory(name=factory.Transformer.Force("Mia")).name
         self.assertEqual(value, "Mia")
@@ -63,6 +71,16 @@ class TransformerTest(TestCase):
             )
         ).name
         self.assertEqual(value, "infinity")
+
+    def test_force_value_declaration_context(self):
+        """Ensure "forced" values run at the right level."""
+        value = UpperFactory(
+            name=factory.Transformer.Force(
+                factory.LazyAttribute(lambda o: o.username.replace(".", " ")),
+            ),
+            username="john.doe",
+        ).name
+        self.assertEqual(value, "john doe")
 
 
 class TestObject:

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -51,6 +51,19 @@ class TransformerTest(TestCase):
         value = UpperFactory(name=factory.Faker("first_name_female", locale="fr")).name
         self.assertIs(value.isupper(), True)
 
+    def test_force_value(self):
+        value = UpperFactory(name=factory.Transformer.Force("Mia")).name
+        self.assertEqual(value, "Mia")
+
+    def test_force_value_declaration(self):
+        """Pretty unlikely use case, but easy enough to cover."""
+        value = UpperFactory(
+            name=factory.Transformer.Force(
+                factory.LazyFunction(lambda: "infinity")
+            )
+        ).name
+        self.assertEqual(value, "infinity")
+
 
 class TestObject:
     def __init__(self, one=None, two=None, three=None):

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -2,7 +2,7 @@
 
 from unittest import TestCase
 
-from factory import Factory, Transformer
+import factory
 
 
 class TransformCounter:
@@ -26,8 +26,8 @@ class Upper:
         self.name = name
 
 
-class UpperFactory(Factory):
-    name = Transformer(transform, "value")
+class UpperFactory(factory.Factory):
+    name = factory.Transformer("value", transform=transform)
 
     class Meta:
         model = Upper
@@ -44,3 +44,156 @@ class TransformerTest(TestCase):
     def test_transform_kwarg(self):
         self.assertEqual("TEST", UpperFactory(name="test").name)
         self.assertEqual(transform.calls_count, 1)
+        self.assertEqual("VALUE", UpperFactory().name)
+        self.assertEqual(transform.calls_count, 2)
+
+    def test_transform_faker(self):
+        value = UpperFactory(name=factory.Faker("first_name_female", locale="fr")).name
+        self.assertIs(value.isupper(), True)
+
+
+class TestObject:
+    def __init__(self, one=None, two=None, three=None):
+        self.one = one
+        self.two = two
+        self.three = three
+
+
+class TransformDeclarationFactory(factory.Factory):
+    class Meta:
+        model = TestObject
+    one = factory.Transformer("", transform=str.upper)
+    two = factory.Transformer(factory.Sequence(int), transform=lambda n: n ** 2)
+
+
+class TransformerSequenceTest(TestCase):
+    def test_on_sequence(self):
+        instance = TransformDeclarationFactory(__sequence=2)
+        self.assertEqual(instance.one, "")
+        self.assertEqual(instance.two, 4)
+        self.assertIsNone(instance.three)
+
+    def test_on_user_supplied(self):
+        """A transformer can wrap a call-time declaration"""
+        instance = TransformDeclarationFactory(
+            one=factory.Sequence(str),
+            two=2,
+            __sequence=2,
+        )
+        self.assertEqual(instance.one, "2")
+        self.assertEqual(instance.two, 4)
+        self.assertIsNone(instance.three)
+
+
+class WithMaybeFactory(factory.Factory):
+    class Meta:
+        model = TestObject
+
+    one = True
+    two = factory.Maybe(
+        'one',
+        yes_declaration=factory.Transformer("yes", transform=str.upper),
+        no_declaration=factory.Transformer("no", transform=str.upper),
+    )
+    three = factory.Maybe('one', no_declaration=factory.Transformer("three", transform=str.upper))
+
+
+class TransformerMaybeTest(TestCase):
+    def test_default_transform(self):
+        instance = WithMaybeFactory()
+        self.assertIs(instance.one, True)
+        self.assertEqual(instance.two, "YES")
+        self.assertIsNone(instance.three)
+
+    def test_yes_transform(self):
+        instance = WithMaybeFactory(one=True)
+        self.assertIs(instance.one, True)
+        self.assertEqual(instance.two, "YES")
+        self.assertIsNone(instance.three)
+
+    def test_no_transform(self):
+        instance = WithMaybeFactory(one=False)
+        self.assertIs(instance.one, False)
+        self.assertEqual(instance.two, "NO")
+        self.assertEqual(instance.three, "THREE")
+
+    def test_override(self):
+        instance = WithMaybeFactory(one=True, two="NI")
+        self.assertIs(instance.one, True)
+        self.assertEqual(instance.two, "NI")
+        self.assertIsNone(instance.three)
+
+
+class RelatedTest(TestCase):
+    def test_default_transform(self):
+        cities = []
+
+        class City:
+            def __init__(self, capital_of, name):
+                self.capital_of = capital_of
+                self.name = name
+                cities.append(self)
+
+        class Country:
+            def __init__(self, name):
+                self.name = name
+
+        class CityFactory(factory.Factory):
+            class Meta:
+                model = City
+
+            name = "Rennes"
+
+        class CountryFactory(factory.Factory):
+            class Meta:
+                model = Country
+
+            name = "France"
+            capital_city = factory.RelatedFactory(
+                CityFactory,
+                factory_related_name="capital_of",
+                name=factory.Transformer("Paris", transform=str.upper),
+            )
+
+        instance = CountryFactory()
+        self.assertEqual(instance.name, "France")
+        [city] = cities
+        self.assertEqual(city.capital_of, instance)
+        self.assertEqual(city.name, "PARIS")
+
+
+class WithTraitFactory(factory.Factory):
+    class Meta:
+        model = TestObject
+
+    class Params:
+        upper_two = factory.Trait(
+            two=factory.Transformer("two", transform=str.upper)
+        )
+        odds = factory.Trait(
+            one="one",
+            three="three",
+        )
+    one = factory.Transformer("one", transform=str.upper)
+
+
+class TransformerTraitTest(TestCase):
+    def test_traits_off(self):
+        instance = WithTraitFactory()
+        self.assertEqual(instance.one, "ONE")
+        self.assertIsNone(instance.two)
+        self.assertIsNone(instance.three)
+
+    def test_trait_transform_applies(self):
+        """A trait-provided transformer should apply to existing values"""
+        instance = WithTraitFactory(upper_two=True)
+        self.assertEqual(instance.one, "ONE")
+        self.assertEqual(instance.two, "TWO")
+        self.assertIsNone(instance.three)
+
+    def test_trait_transform_applies_supplied(self):
+        """A trait-provided transformer should be overridden by caller-provided values"""
+        instance = WithTraitFactory(upper_two=True, two="two")
+        self.assertEqual(instance.one, "ONE")
+        self.assertEqual(instance.two, "two")
+        self.assertIsNone(instance.three)


### PR DESCRIPTION
Based on the approach in #1006, rework the implementation for readability and shared features.

Mostly:
- Add a mechanism for declarations to be able to work on call-time values passed in their name;
- Share the code responsible with evaluating a wrapped declaration at the right level;
- Add extra tests ensuring wrapped declarations are evaluated within the right level/stub.