### PR TITLE
Upgrade intersphinx mapping for Sphinx 8

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,7 +79,7 @@ linkcheck_retries = 3
 
 # -- intersphinx -------------------------------------------------------------
 intersphinx_mapping = {
-    'https://docs.python.org/': None,
+    'python': ('https://docs.python.org/3', None),
     'django': (
         'https://docs.djangoproject.com/en/dev/',
         'https://docs.djangoproject.com/en/dev/_objects/',


### PR DESCRIPTION
WARNING: The pre-Sphinx 1.0 'intersphinx_mapping' format is deprecated and will be removed in Sphinx 8. Update to the current format as described in the documentation. Hint: "intersphinx_mapping = {'<name>': ('https://docs.python.org/', None)}".https://www.sphinx-doc.org/en/master/us
age/extensions/intersphinx.html#confval-intersphinx_mapping

https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping