### PR TITLE
Add Choice declaration

### DIFF
--- a/factory/declarations.py
+++ b/factory/declarations.py
@@ -1,11 +1,10 @@
 # Copyright: See the LICENSE file.
 
-
 import itertools
 import logging
 import typing as T
 
-from . import enums, errors, utils
+from . import enums, errors, random, utils
 
 logger = logging.getLogger('factory.generate')
 
@@ -243,6 +242,20 @@ class Sequence(BaseDeclaration):
     def evaluate(self, instance, step, extra):
         logger.debug("Sequence: Computing next value of %r for seq=%s", self.function, step.sequence)
         return self.function(int(step.sequence))
+
+
+class Choice(BaseDeclaration):
+    """Fill this value using a random value from the choices.
+
+    Attributes:
+        choices: A collection of valid values
+    """
+    def __init__(self, choices):
+        super().__init__()
+        self.choices = choices
+
+    def evaluate(self, instance, step, extra):
+        return random.randgen.choice(self.choices)
 
 
 class LazyAttributeSequence(Sequence):

--- a/tests/test_declarations.py
+++ b/tests/test_declarations.py
@@ -132,6 +132,22 @@ class IteratorTestCase(unittest.TestCase):
         self.assertEqual(3, utils.evaluate_declaration(it, force_sequence=3))
 
 
+class ChoiceTestCase(unittest.TestCase):
+    def test_choice(self):
+        choices = [1, 2, 3]
+
+        it = declarations.Choice(choices)
+
+        self.assertIn(utils.evaluate_declaration(it), choices)
+
+    def test_seeding(self):
+        choices = [1, 2, 3]
+        it = declarations.Choice(choices)
+
+        with mock.patch('factory.random.randgen.choice', lambda _: 2):
+            self.assertEqual(2, utils.evaluate_declaration(it))
+
+
 class TransformerTestCase(unittest.TestCase):
     def test_transform(self):
         t = declarations.Transformer(lambda x: x.upper(), 'foo')


### PR DESCRIPTION
I frequently find myself doing something a long these lines:

```python
factory.LazyFunction(lambda: random.choice(["x", "y"]))
```
