### PR TITLE
Remove zip_safe flag from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ classifiers =
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]
-zip_safe = false
 packages = factory
 python_requires = >=3.7
 install_requires =


### PR DESCRIPTION
https://setuptools.pypa.io/en/latest/deprecated/zip_safe.html#understanding-the-zip-safe-flag

> It is very unlikely that the values of zip_safe will affect modern
  deployments that use pip for installing packages. Moreover, new users
  of setuptools should not attempt to create egg files using the
  deprecated build_egg command. Therefore, this flag is considered
  obsolete.