### PR TITLE
Fix CI against Django main

### DIFF
--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -585,8 +585,8 @@ class DjangoFileFieldTestCase(django_test.TestCase):
             o = WithFileFactory.build(afile__from_file=f)
             o.save()
 
-        with o.afile as f:
-            self.assertEqual(b'example_data\n', f.read())
+            with o.afile as f:
+                self.assertEqual(b'example_data\n', f.read())
         self.assertEqual('django/example.data', o.afile.name)
 
     def test_with_path(self):
@@ -609,8 +609,8 @@ class DjangoFileFieldTestCase(django_test.TestCase):
             # Django only allocates the full path on save()
             o.save()
 
-        with o.afile as f:
-            self.assertEqual(b'example_data\n', f.read())
+            with o.afile as f:
+                self.assertEqual(b'example_data\n', f.read())
         self.assertEqual('django/example.data', o.afile.name)
 
     def test_with_path_empty_file(self):


### PR DESCRIPTION
It’s actually revealing an issue from the FactoryBoy test suite.

```
Traceback (most recent call last):
  File "/home/runner/work/factory_boy/factory_boy/tests/test_django.py", line 833, in test_with_file_empty_path
    self.assertEqual(301, len(f.read()))
ValueError: read of closed file
```