### PR TITLE
Update official python/django versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
-          - "pypy-3.7"
           - "pypy-3.8"
           - "pypy-3.9"
         database-type:

--- a/README.rst
+++ b/README.rst
@@ -8,10 +8,10 @@ factory_boy
     :target: https://github.com/FactoryBoy/factory_boy/actions?query=workflow%3ACheck
 
 .. image:: https://img.shields.io/pypi/v/factory_boy.svg
-    :target: https://factoryboy.readthedocs.io/en/latest/changelog.html
+    :target: https://pypi.org/project/factory-boy/
     :alt: Latest Version
 
-.. image:: https://img.shields.io/pypi/pyversions/factory_boy.svg
+.. image:: https://img.shields.io/badge/python-3.8%20|%203.9%20|%203.10%20|%203.11-blue.svg
     :target: https://pypi.org/project/factory-boy/
     :alt: Supported Python versions
 
@@ -20,7 +20,7 @@ factory_boy
     :alt: Wheel status
 
 .. image:: https://img.shields.io/pypi/l/factory_boy.svg
-    :target: https://pypi.org/project/factory-boy/
+    :target: https://github.com/FactoryBoy/factory_boy/blob/master/LICENSE
     :alt: License
 
 factory_boy is a fixtures replacement based on thoughtbot's `factory_bot <https://github.com/thoughtbot/factory_bot>`_.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,8 +12,8 @@ ChangeLog
       passwords.
     - :issue:`304`: Add :attr:`~factory.alchemy.SQLAlchemyOptions.sqlalchemy_session_factory` to dynamically
       create sessions for use by the :class:`~factory.alchemy.SQLAlchemyModelFactory`.
-    - Add support for Django 4.0
     - Add support for Django 4.1
+    - Add support for Django 4.2
     - Add support for Python 3.10
     - Add support for Python 3.11
 
@@ -51,6 +51,7 @@ ChangeLog
     - Drop support for Django 3.0
     - Drop support for Django 3.1
     - Drop support for Python 3.6
+    - Drop support for Python 3.7
 
 3.2.1 (2021-10-26)
 ------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,15 +16,14 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Framework :: Django
     Framework :: Django :: 3.2
-    Framework :: Django :: 4.0
     Framework :: Django :: 4.1
+    Framework :: Django :: 4.2
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -36,7 +35,7 @@ classifiers =
 
 [options]
 packages = factory
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     Faker>=0.7.0
     importlib_metadata;python_version<"3.8"

--- a/tox.ini
+++ b/tox.ini
@@ -5,20 +5,19 @@ envlist =
     docs
     examples
     linkcheck
-    py{37,38,39,310,311,py37,py38,py39}-sqlite
-    py{37,38,39,310,311,py37,py38,py39}-django32-mongo-alchemy-{sqlite,postgres}
-    py{38,39,310,311,py38,py39}-django40-mongo-alchemy-{sqlite,postgres}
-    py{38,39,310,311,py38,py39}-django41-mongo-alchemy-{sqlite,postgres}
+    py{38,39,310,311,py38,py39}-sqlite
+    py{38,39,310,311,py38,py39}-django32-mongo-alchemy-{sqlite,postgres}
+    py{38,39,310,311,py38,py39}-django{41}-mongo-alchemy-{sqlite,postgres}
+    # psycopg2cffi needs to be updated to support Django 4.2
+    py{38,39,310,311}-django{42}-mongo-alchemy-{sqlite,postgres}
     py310-djangomain-mongo-alchemy-{sqlite,postgres}
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
-    pypy-3.7: pypy37
     pypy-3.8: pypy38
     pypy-3.9: pypy39
 
@@ -36,13 +35,13 @@ deps =
     alchemy: SQLAlchemy
     alchemy: sqlalchemy_utils
     mongo: mongoengine
-    django{32,40,41,main}: Pillow
+    django{32,41,42,main}: Pillow
     django32: Django>=3.2,<3.3
-    django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<4.3
     djangomain: https://github.com/django/django/archive/main.tar.gz
-    py{37,38,39,310,311}-postgres: psycopg2-binary
-    pypy{37,38,39}-postgres: psycopg2cffi
+    py{38,39,310,311}-postgres: psycopg2-binary
+    pypy{38,39}-postgres: psycopg2cffi
 
 setenv =
     py: DJANGO_SETTINGS_MODULE=tests.djapp.settings


### PR DESCRIPTION
Hi

I've made this PR that 

- add support for Django 4.2
- drop support for python 3.7 (EOL https://devguide.python.org/versions/#unsupported-versions)
- drop support for Django 4.0 (EOL https://www.djangoproject.com/download/#unsupported-versions)

can we also have a new release after this PR is merged?

Thanks,

REF: https://github.com/edx/upgrades/issues/307