### PR TITLE
Don't require setting sqlalchemy_session to None when using a factory.

### DIFF
--- a/factory/alchemy.py
+++ b/factory/alchemy.py
@@ -24,8 +24,11 @@ class SQLAlchemyOptions(base.FactoryOptions):
 
     @staticmethod
     def _check_has_sqlalchemy_session_set(meta, value):
-        if value and meta.sqlalchemy_session:
-            raise RuntimeError("Provide either a sqlalchemy_session or a sqlalchemy_session_factory, not both")
+        try:
+            if value and meta.sqlalchemy_session:
+                raise RuntimeError("Provide either a sqlalchemy_session or a sqlalchemy_session_factory, not both")
+        except AttributeError:
+            pass
 
     def _build_default_options(self):
         return super()._build_default_options() + [

--- a/tests/test_alchemy.py
+++ b/tests/test_alchemy.py
@@ -286,7 +286,6 @@ class SQLAlchemySessionFactoryTestCase(TransactionTestCase):
         class SessionGetterFactory(SQLAlchemyModelFactory):
             class Meta:
                 model = models.StandardModel
-                sqlalchemy_session = None
                 sqlalchemy_session_factory = lambda: models.session
 
             id = factory.Sequence(lambda n: n)


### PR DESCRIPTION
fixes FactoryBoy/factory_boy#1031

This fix makes it so that `sqlalchemy_session_factory` can be used without explicitly setting `sqlalchemy_session=None` in a metaclass.