### PR TITLE
Add version added to docs for `Transformer`

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -909,6 +909,8 @@ Transformer
 
 .. class:: Transformer(default_value, *, transform)
 
+   .. versionadded:: 3.3.0
+
 A :class:`Transformer` applies a ``transform`` function to the provided value
 before to set the transformed value on the generated object.
 


### PR DESCRIPTION
This was added in version 3.3.0, but has no marker that says that.

This change adds the marker to make it clear to users reading the 'stable' docs that this might not be available in their version.