### PR TITLE
Update alchemy.py

### DIFF
--- a/factory/alchemy.py
+++ b/factory/alchemy.py
@@ -25,7 +25,7 @@ class SQLAlchemyOptions(base.FactoryOptions):
     @staticmethod
     def _check_has_sqlalchemy_session_set(meta, value):
         try:
-            if value and meta.sqlalchemy_session:
+            if value and hasattr(meta, "sqlalchemy_session"):
                 raise RuntimeError("Provide either a sqlalchemy_session or a sqlalchemy_session_factory, not both")
         except AttributeError:
             pass


### PR DESCRIPTION
hotfix for line 27: if `sqlalchemy_session` is not declared as `None`, then an attribute error is raised. Using `hasattr` avoids this issue since the function will return `False` if `sqlalchemy_session` is not declared in `class Meta`