### PR TITLE
Fixed mute_signals restoring signals receiver order.

### DIFF
--- a/factory/django.py
+++ b/factory/django.py
@@ -311,7 +311,7 @@ class mute_signals:
             logger.debug('mute_signals: Restoring signal handlers %r',
                          receivers)
 
-            signal.receivers += receivers
+            signal.receivers = receivers + signal.receivers
             with signal.lock:
                 # Django uses some caching for its signals.
                 # Since we're bypassing signal.connect and signal.disconnect,

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -941,6 +941,22 @@ class PreventSignalsTestCase(django_test.TestCase):
 
         self.assertTrue(self.handlers.created_during_instantiation.called)
 
+    def test_signal_receiver_order_restored_after_mute_signals(self):
+        def must_be_first(*args, **kwargs):
+            self.handlers.do_stuff(1)
+
+        def must_be_second(*args, **kwargs):
+            self.handlers.do_stuff(2)
+
+        signals.post_save.connect(must_be_first)
+        with factory.django.mute_signals(signals.post_save):
+            WithSignalsFactory(post_save_signal_receiver=must_be_second)
+            self.handlers.do_stuff.assert_has_calls([mock.call(2)])
+
+        self.handlers.reset_mock()
+        WithSignalsFactory(post_save_signal_receiver=must_be_second)
+        self.handlers.do_stuff.assert_has_calls([mock.call(1), mock.call(2)])
+
     def test_signal_cache(self):
         with factory.django.mute_signals(signals.pre_save, signals.post_save):
             signals.post_save.connect(self.handlers.mute_block_receiver)

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -951,11 +951,11 @@ class PreventSignalsTestCase(django_test.TestCase):
         signals.post_save.connect(must_be_first)
         with factory.django.mute_signals(signals.post_save):
             WithSignalsFactory(post_save_signal_receiver=must_be_second)
-            self.handlers.do_stuff.assert_has_calls([mock.call(2)])
+            self.assertEqual(self.handlers.do_stuff.call_args_list, [mock.call(2)])
 
         self.handlers.reset_mock()
         WithSignalsFactory(post_save_signal_receiver=must_be_second)
-        self.handlers.do_stuff.assert_has_calls([mock.call(1), mock.call(2)])
+        self.assertEqual(self.handlers.do_stuff.call_args_list, [mock.call(1), mock.call(2)])
 
     def test_signal_cache(self):
         with factory.django.mute_signals(signals.pre_save, signals.post_save):


### PR DESCRIPTION
We have multiple signal receivers on our Django project and the order that they are called is important. 
We found that this update https://github.com/FactoryBoy/factory_boy/commit/3a827f098cc3ac8003e81b18e42e0d14a9b2e2e3 changed the order of signal receivers which broke a few of our tests
For example we use the package `django-dirtyfields` and the order of the post_save signal for this package is very important

This might be related to https://github.com/FactoryBoy/factory_boy/issues/895