### PR TITLE
GitHub Actions: Test PyPy 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,8 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-          - "pypy-3.8"
           - "pypy-3.9"
+          - "pypy-3.10"
         database-type:
           - "sqlite"
           - "postgres"
@@ -42,7 +42,7 @@ jobs:
           POSTGRES_PASSWORD: password
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,10 @@ envlist =
     docs
     examples
     linkcheck
-    py{38,39,310,311,py38,py39}-sqlite
-    py{38,39,310,311,py38,py39}-django32-mongo-alchemy-{sqlite,postgres}
-    py{38,39,310,311,py38,py39}-django40-mongo-alchemy-{sqlite,postgres}
-    py{38,39,310,311,py38,py39}-django41-mongo-alchemy-{sqlite,postgres}
+    py{38,39,310,311,py39,py310}-sqlite
+    py{38,39,310,311,py39,py310}-django32-mongo-alchemy-{sqlite,postgres}
+    py{38,39,310,311,py39,py310}-django40-mongo-alchemy-{sqlite,postgres}
+    py{38,39,310,311,py39,py310}-django41-mongo-alchemy-{sqlite,postgres}
     py310-djangomain-mongo-alchemy-{sqlite,postgres}
 
 [gh-actions]
@@ -18,8 +18,8 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
-    pypy-3.8: pypy38
     pypy-3.9: pypy39
+    pypy-3.10: pypy310
 
 [gh-actions:env]
 DATABASE_TYPE =
@@ -39,10 +39,10 @@ deps =
     django32: Django>=3.2,<3.3
     django41: Django>=4.1,<4.2
     django42: Django>=4.2,<5.0
-    django50: Django>=5.0b1,<5.1
+    django50: Django>=5.0,<5.1
     djangomain: https://github.com/django/django/archive/main.tar.gz
     py{38,39,310,311}-postgres: psycopg2-binary
-    pypy{38,39}-postgres: psycopg2cffi
+    pypy{39,310}-postgres: psycopg2cffi
 
 setenv =
     py: DJANGO_SETTINGS_MODULE=tests.djapp.settings


### PR DESCRIPTION
https://www.pypy.org/download.html -- Adds PyPy3.10 and drops PyPy3.8.

Also, upgrade GitHub Actions `checkout` and `setup-python`.  Automated in:
* #1021
https://github.com/actions/checkout/releases
https://github.com/actions/setup-python/releases