### PR TITLE
tox.ini: Enable testing on Django v5.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
     py{38,39,310,311,py39,py310}-django32-mongo-alchemy-{sqlite,postgres}
     py{38,39,310,311,py39,py310}-django40-mongo-alchemy-{sqlite,postgres}
     py{38,39,310,311,py39,py310}-django41-mongo-alchemy-{sqlite,postgres}
+    py{310,311,312}-django50-mongo-alchemy-{sqlite,postgres}
     py310-djangomain-mongo-alchemy-{sqlite,postgres}
 
 [gh-actions]
@@ -41,7 +42,7 @@ deps =
     django42: Django>=4.2,<5.0
     django50: Django>=5.0,<5.1
     djangomain: https://github.com/django/django/archive/main.tar.gz
-    py{38,39,310,311}-postgres: psycopg2-binary
+    py{38,39,310,311,312}-postgres: psycopg2-binary
     pypy{39,310}-postgres: psycopg2cffi
 
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     docs
     examples
     linkcheck
-    py{38,39,310,311,py39,py310}-sqlite
+    py{38,39,310,311,312,py39,py310}-sqlite
     py{38,39,310,311,py39,py310}-django32-mongo-alchemy-{sqlite,postgres}
     py{38,39,310,311,py39,py310}-django40-mongo-alchemy-{sqlite,postgres}
     py{38,39,310,311,py39,py310}-django41-mongo-alchemy-{sqlite,postgres}

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,9 @@ envlist =
     py{38,39,310,311,312,py39,py310}-sqlite
     py{38,39,310,311,py39,py310}-django32-mongo-alchemy-{sqlite,postgres}
     py{38,39,310,311,py39,py310}-django41-mongo-alchemy-{sqlite,postgres}
-    py{38,39,310,311,312,py39,py310}-django42-mongo-alchemy-{sqlite,postgres}
+    py{38,39,310,311,312}-django42-mongo-alchemy-{sqlite,postgres}
+    py{py39,py310}-django42-mongo-alchemy-sqlite,
+    # py{py39,py310}-django42-mongo-alchemy-postgres  # TODO: Fix me!
     py{310,311,312}-django50-mongo-alchemy-{sqlite,postgres}
     py310-djangomain-mongo-alchemy-{sqlite,postgres}
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,8 @@ envlist =
     linkcheck
     py{38,39,310,311,312,py39,py310}-sqlite
     py{38,39,310,311,py39,py310}-django32-mongo-alchemy-{sqlite,postgres}
-    py{38,39,310,311,py39,py310}-django40-mongo-alchemy-{sqlite,postgres}
     py{38,39,310,311,py39,py310}-django41-mongo-alchemy-{sqlite,postgres}
+    py{38,39,310,311,312,py39,py310}-django42-mongo-alchemy-{sqlite,postgres}
     py{310,311,312}-django50-mongo-alchemy-{sqlite,postgres}
     py310-djangomain-mongo-alchemy-{sqlite,postgres}
 


### PR DESCRIPTION
https://pypi.org/project/Django

https://www.djangoproject.com/weblog/2023/dec/04/django-50-released

> Django 4.1 has reached the end of extended support. The final security release ([4.1.13](https://docs.djangoproject.com/en/stable/releases/4.1.13/)) was issued on November 1st. All Django 4.1 users are encouraged to [upgrade](https://docs.djangoproject.com/en/dev/howto/upgrade-version/) to Django 4.2 or later.

https://docs.djangoproject.com/en/5.0/releases/5.0
> Django 5.0 supports Python 3.10, 3.11, and 3.12.