### PR TITLE
Add missing generic on `Factory` subclasses

### DIFF
--- a/factory/alchemy.py
+++ b/factory/alchemy.py
@@ -1,9 +1,13 @@
 # Copyright: See the LICENSE file.
 
+from typing import TypeVar
+
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
 from . import base, errors
+
+T = TypeVar("T")
 
 SESSION_PERSISTENCE_COMMIT = 'commit'
 SESSION_PERSISTENCE_FLUSH = 'flush'
@@ -46,7 +50,7 @@ class SQLAlchemyOptions(base.FactoryOptions):
         ]
 
 
-class SQLAlchemyModelFactory(base.Factory):
+class SQLAlchemyModelFactory(base.Factory[T]):
     """Factory for SQLAlchemy models. """
 
     _options_class = SQLAlchemyOptions

--- a/factory/base.py
+++ b/factory/base.py
@@ -656,7 +656,7 @@ class StubObject:
             setattr(self, field, value)
 
 
-class StubFactory(Factory):
+class StubFactory(Factory[T]):
 
     class Meta:
         strategy = enums.STUB_STRATEGY
@@ -671,7 +671,7 @@ class StubFactory(Factory):
         raise errors.UnsupportedStrategy()
 
 
-class BaseDictFactory(Factory):
+class BaseDictFactory(Factory[T]):
     """Factory for dictionary-like classes."""
     class Meta:
         abstract = True
@@ -688,12 +688,12 @@ class BaseDictFactory(Factory):
         return cls._build(model_class, *args, **kwargs)
 
 
-class DictFactory(BaseDictFactory):
+class DictFactory(BaseDictFactory[T]):
     class Meta:
         model = dict
 
 
-class BaseListFactory(Factory):
+class BaseListFactory(Factory[T]):
     """Factory for list-like classes."""
     class Meta:
         abstract = True
@@ -714,7 +714,7 @@ class BaseListFactory(Factory):
         return cls._build(model_class, *args, **kwargs)
 
 
-class ListFactory(BaseListFactory):
+class ListFactory(BaseListFactory[T]):
     class Meta:
         model = list
 

--- a/factory/mogo.py
+++ b/factory/mogo.py
@@ -2,12 +2,13 @@
 
 
 """factory_boy extensions for use with the mogo library (pymongo wrapper)."""
-
+from typing import TypeVar
 
 from . import base
 
+T = TypeVar("T")
 
-class MogoFactory(base.Factory):
+class MogoFactory(base.Factory[T]):
     """Factory for mogo objects."""
     class Meta:
         abstract = True

--- a/factory/mongoengine.py
+++ b/factory/mongoengine.py
@@ -2,12 +2,13 @@
 
 
 """factory_boy extensions for use with the mongoengine library (pymongo wrapper)."""
-
+from typing import TypeVar
 
 from . import base
 
+T = TypeVar("T")
 
-class MongoEngineFactory(base.Factory):
+class MongoEngineFactory(base.Factory[T]):
     """Factory for mongoengine objects."""
 
     class Meta:


### PR DESCRIPTION
Following #1059, subclasses were missing the type var, making it impossible to parametrize at runtime.

---

There's a couple places where I'd like to see typing added (e.g. `LazyAttribute` and friend callables arguments). They should be pretty straightforward, would you like to have a PR implementing it?