### PR TITLE
Remove unnecessary py3.8 compat path

### DIFF
--- a/factory/__init__.py
+++ b/factory/__init__.py
@@ -1,6 +1,6 @@
 # Copyright: See the LICENSE file.
 
-import sys
+import importlib.metadata
 
 from .base import (
     BaseDictFactory,
@@ -72,10 +72,4 @@ except ImportError:
     pass
 
 __author__ = 'Raphaël Barrois <raphael.barrois+fboy@polytechnique.org>'
-if sys.version_info >= (3, 8):
-    # Python 3.8+
-    import importlib.metadata as importlib_metadata
-else:
-    import importlib_metadata
-
-__version__ = importlib_metadata.version("factory_boy")
+__version__ = importlib.metadata.version("factory_boy")


### PR DESCRIPTION
We now supports 3.8+