### PR TITLE
Call evaluate_pre() instead of evaluate() on Maybe decider

### DIFF
--- a/factory/declarations.py
+++ b/factory/declarations.py
@@ -536,7 +536,7 @@ class Maybe(BaseDeclaration):
             return target
 
     def evaluate_pre(self, instance, step, overrides):
-        choice = self.decider.evaluate(instance=instance, step=step, extra={})
+        choice = self.decider.evaluate_pre(instance=instance, step=step, overrides={})
         target = self.yes if choice else self.no
         # The value can't be POST_INSTANTIATION, checked in __init__;
         # evaluate it as `evaluate_pre`

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -51,3 +51,24 @@ class FakerRegressionTests(unittest.TestCase):
 
         unknown_author = AuthorFactory(unknown=True)
         self.assertEqual("", unknown_author.fullname)
+
+    def test_evaluated_without_locale(self):
+        """Regression test for `KeyError: 'locale'` raised in `evaluate`.
+
+        See #965
+
+        """
+        class AuthorFactory(factory.Factory):
+            fullname = factory.Faker("name")
+            pseudonym = factory.Maybe(
+                decider=factory.Faker("pybool"),
+                yes_declaration="yes",
+                no_declaration="no",
+            )
+
+            class Meta:
+                model = Author
+
+        author = AuthorFactory()
+
+        self.assertIn(author.pseudonym, ["yes", "no"])


### PR DESCRIPTION
e19142c introduced `evaluate_pre()` to perform context unrolling before to call the semi-public `evaluate()`.

The Maybe decider was not updated at that time, but its context need to be unrolled.

Closes #965 
