### PR TITLE
Allow functions as models

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ ChangeLog
 
 - :issue:`1031`: Do not require :attr:`~factory.alchemy.SQLAlchemyOptions.sqlalchemy_session` when
   :attr:`~factory.alchemy.SQLAlchemyOptions.sqlalchemy_session_factory` is provided.
+- :issue:`1072`: Allow using functions as models for a :attr:`~factory.FactoryOptions.model`.
 
 *Removed:*
 

--- a/factory/base.py
+++ b/factory/base.py
@@ -2,6 +2,7 @@
 
 
 import collections
+import inspect
 import logging
 import warnings
 from typing import Generic, List, Type, TypeVar
@@ -243,6 +244,7 @@ class FactoryOptions:
         if (self.model is not None
                 and self.base_factory is not None
                 and self.base_factory._meta.model is not None
+                and inspect.isclass(self.model)
                 and issubclass(self.model, self.base_factory._meta.model)):
             return self.base_factory._meta.counter_reference
         else:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -281,6 +281,22 @@ class FactoryTestCase(unittest.TestCase):
         ones = {x.one for x in (parent, alt_parent, sub, alt_sub)}
         self.assertEqual(4, len(ones))
 
+    def test_inheritance_with_function_as_meta_model(self):
+        def make_test_object(**kwargs):
+            return TestObject(**kwargs)
+
+        class TestObjectFactory(base.Factory):
+            class Meta:
+                model = make_test_object
+
+            one = "foo"
+
+        class TestSubFactory(TestObjectFactory):
+            one = "bar"
+
+        sub = TestSubFactory.build()
+        self.assertEqual(sub.one, "bar")
+
 
 class FactorySequenceTestCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Hi,

in our project, we're using factories for our models:

```python
# domain/factories.py
from . import model, events

def item_factory(sku: str, price: float):
    obj = model.Item(sku, price)
    obj.events.append(events.ItemCreated())
    return obj
```

Now, in our tests we want factory boy to call those factories instead of the model classes directly, which works perfectly except in this case:

```python
# tests/factories.py
class ItemFactory(factory.Factory):
    class Meta:
        model = factories.item_factory
    sku = ...
    price = ...

class SpecialItemFactory(ItemFactory):  # Inherits from the factory above
    sku = "special"
```

When a factory inherits from another factory, `FactoryOptions._get_counter_reference` expects the assigned model to be a class, because `issubclass` raises:

```
TypeError: issubclass() arg 1 must be a class
```

We couldn't find a fix for this case so I've opened this PR. If my solution is wrong or if anything is missing in my commit, please don't hesitate to let me know.

BR