### PR TITLE
Default ReadTheDocs to Ubuntu / Python `latest`

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -2,9 +2,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: "ubuntu-lts-latest"
   tools:
-    python: "3.11"
+    python: "latest"
 
 python:
   install:


### PR DESCRIPTION
I noticed that we're not ensuring the docs build under `3.12`, plus `24.04` will be released later this month (although may take RTD a bit longer to pull it in).

Looking at [the docs](https://docs.readthedocs.io/en/stable/config-file/v2.html), there's a `latest` variant for both.

It comes with a warning that using latest may unexpectedly break builds if the project isn't compatible... But I think for our use case the odds that it will break are extremely low (and in fact we'd want to know it's broken so we could fix it!) Plus if it starts breaking, it's not hard to temp pin it to an older version.

So all-in-all, both lower maintenance and faster realization of breakage if we default to latest on both of these.