### PR TITLE
Allow running the mongo test suite against mongomock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ test:
 		-Wdefault:"parameter codeset is deprecated":DeprecationWarning:: \
 		-Wdefault:"'cgi' is deprecated and slated for removal in Python 3.13":DeprecationWarning:: \
 		-Wdefault:"datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version.":DeprecationWarning:: \
+		-Wdefault:"pkg_resources is deprecated as an API.":DeprecationWarning:: \
 		-m unittest
 
 # DOC: Test the examples

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ dev =
     SQLAlchemy
     sqlalchemy_utils
     mongoengine
+    mongomock
     wheel>=0.32.0
     tox
     zest.releaser[recommended]

--- a/tests/test_mongoengine.py
+++ b/tests/test_mongoengine.py
@@ -59,12 +59,12 @@ class BaseMongoEngineTestCase:
             **kwargs,
         )
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.db.drop_database(cls.db_name)
-        mongoengine.connection.disconnect()
-        PersonFactory.reset_sequence()
-        AddressFactory.reset_sequence()
+        def cleanup():
+            cls.db.drop_database(cls.db_name)
+            mongoengine.connection.disconnect()
+            PersonFactory.reset_sequence()
+            AddressFactory.reset_sequence()
+        cls.addClassCleanup(cleanup)
 
     def test_build(self):
         std = PersonFactory.build()

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ DATABASE_TYPE =
 [testenv]
 passenv =
     MONGO_HOST
+    MONGO_USE_MOCK
     POSTGRES_HOST
     POSTGRES_DATABASE
 deps =
@@ -38,6 +39,9 @@ deps =
     alchemy: SQLAlchemy
     alchemy: sqlalchemy_utils
     mongo: mongoengine
+    mongo: mongomock
+    # mongomock imports pkg_resources, provided by setuptools.
+    mongo: setuptools>=66.1.1
     django{32,42,50,main}: Pillow
     django32: Django>=3.2,<3.3
     django42: Django>=4.2,<5.0


### PR DESCRIPTION
Running tests in a mock environment would be helpful to packagers for Arch Linux, and maybe others. They do not have access to a running MongoDB instance in the package build environment but would still like to run smoke tests against the package.

The tests against `mongomock` have been included in the regular test suite to keep verifying that environment.

Tests that require a MongoDB instance can be skipped by setting the environment variable `MONGO_USE_MOCK=1`.

Support is being provided on a best-effort basis, to help downstream packagers. FactoryBoy could remove support for this feature if it ends up being an issue, as the usage is fairly niche. Requiring a MongoDB instance to run the Mongo test suite does not seem unreasonable.

Closes #1081
