### PR TITLE
Update SQLAlchemy factory base to support generic typing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ ChangeLog
 3.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add typing information to SQLAlchemy model factory
 
 
 3.3.1 (2024-08-18)

--- a/factory/alchemy.py
+++ b/factory/alchemy.py
@@ -1,5 +1,7 @@
 # Copyright: See the LICENSE file.
 
+from typing import TypeVar
+
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -12,6 +14,7 @@ VALID_SESSION_PERSISTENCE_TYPES = [
     SESSION_PERSISTENCE_COMMIT,
     SESSION_PERSISTENCE_FLUSH,
 ]
+T = TypeVar('T')
 
 
 class SQLAlchemyOptions(base.FactoryOptions):
@@ -43,7 +46,7 @@ class SQLAlchemyOptions(base.FactoryOptions):
         ]
 
 
-class SQLAlchemyModelFactory(base.Factory):
+class SQLAlchemyModelFactory(base.Factory[T]):
     """Factory for SQLAlchemy models. """
 
     _options_class = SQLAlchemyOptions


### PR DESCRIPTION
This extends https://github.com/FactoryBoy/factory_boy/pull/1059 to support SQLAlchemy as well.