### PR TITLE
feat: Add generic support for SQLAlchemyModelFactory

### DIFF
--- a/factory/alchemy.py
+++ b/factory/alchemy.py
@@ -1,5 +1,7 @@
 # Copyright: See the LICENSE file.
 
+from typing import TypeVar
+
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -12,6 +14,8 @@ VALID_SESSION_PERSISTENCE_TYPES = [
     SESSION_PERSISTENCE_COMMIT,
     SESSION_PERSISTENCE_FLUSH,
 ]
+
+T = TypeVar("T")
 
 
 class SQLAlchemyOptions(base.FactoryOptions):
@@ -43,7 +47,7 @@ class SQLAlchemyOptions(base.FactoryOptions):
         ]
 
 
-class SQLAlchemyModelFactory(base.Factory):
+class SQLAlchemyModelFactory(base.Factory[T]):
     """Factory for SQLAlchemy models. """
 
     _options_class = SQLAlchemyOptions


### PR DESCRIPTION
This PR extends the typing support added in #903 to allow `SQLAlchemyModelFactory` to specify its generic type as well.

(We have some custom extensions in use on top of `SQLAlchemyModelFactory`, which make use of generics - the additions from #903 are a breaking change for us because it creates an MRO issue with `Generic`)