### PR TITLE
feat: Add generic typing to factories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ dist/
 htmlcov/
 MANIFEST
 tags
+
+# Virtualenv
+.venv/
+venv/

--- a/factory/alchemy.py
+++ b/factory/alchemy.py
@@ -43,7 +43,7 @@ class SQLAlchemyOptions(base.FactoryOptions):
         ]
 
 
-class SQLAlchemyModelFactory(base.Factory):
+class SQLAlchemyModelFactory(base.Factory[base.T]):
     """Factory for SQLAlchemy models. """
 
     _options_class = SQLAlchemyOptions

--- a/factory/base.py
+++ b/factory/base.py
@@ -666,7 +666,7 @@ class StubObject:
             setattr(self, field, value)
 
 
-class StubFactory(Factory):
+class StubFactory(Factory[StubObject]):
 
     class Meta:
         strategy = enums.STUB_STRATEGY
@@ -681,7 +681,7 @@ class StubFactory(Factory):
         raise errors.UnsupportedStrategy()
 
 
-class BaseDictFactory(Factory):
+class BaseDictFactory(Factory[T]):
     """Factory for dictionary-like classes."""
     class Meta:
         abstract = True
@@ -698,12 +698,12 @@ class BaseDictFactory(Factory):
         return cls._build(model_class, *args, **kwargs)
 
 
-class DictFactory(BaseDictFactory):
+class DictFactory(BaseDictFactory[dict]):
     class Meta:
         model = dict
 
 
-class BaseListFactory(Factory):
+class BaseListFactory(Factory[T]):
     """Factory for list-like classes."""
     class Meta:
         abstract = True
@@ -724,7 +724,7 @@ class BaseListFactory(Factory):
         return cls._build(model_class, *args, **kwargs)
 
 
-class ListFactory(BaseListFactory):
+class ListFactory(BaseListFactory[list]):
     class Meta:
         model = list
 

--- a/factory/mogo.py
+++ b/factory/mogo.py
@@ -7,7 +7,7 @@
 from . import base
 
 
-class MogoFactory(base.Factory):
+class MogoFactory(base.Factory[base.T]):
     """Factory for mogo objects."""
     class Meta:
         abstract = True

--- a/factory/mongoengine.py
+++ b/factory/mongoengine.py
@@ -7,7 +7,7 @@
 from . import base
 
 
-class MongoEngineFactory(base.Factory):
+class MongoEngineFactory(base.Factory[base.T]):
     """Factory for mongoengine objects."""
 
     class Meta:

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -36,9 +36,9 @@ class TypingTests(unittest.TestCase):
             species = "dog"
             name = "rover"
 
-        self.assertTrue(isinstance(Pet.build(), dict))
-        self.assertTrue(isinstance(Pet.create(), dict))
+        self.assertIsInstance(Pet.build(), dict)
+        self.assertIsInstance(Pet.create(), dict)
 
     def test_list_factory(self) -> None:
-        self.assertTrue(isinstance(factory.ListFactory.build(), list))
-        self.assertTrue(isinstance(factory.ListFactory.create(), list))
+        self.assertIsInstance(factory.ListFactory.build(), list)
+        self.assertIsInstance(factory.ListFactory.create(), list)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -3,6 +3,8 @@
 import dataclasses
 import unittest
 
+from typing_extensions import assert_type
+
 import factory
 
 
@@ -14,9 +16,7 @@ class User:
 
 
 class TypingTests(unittest.TestCase):
-
     def test_simple_factory(self) -> None:
-
         class UserFactory(factory.Factory[User]):
             name = "John Doe"
             email = "john.doe@example.org"
@@ -25,7 +25,20 @@ class TypingTests(unittest.TestCase):
             class Meta:
                 model = User
 
-        result: User
-        result = UserFactory.build()
-        result = UserFactory.create()
-        self.assertEqual(result.name, "John Doe")
+        assert_type(UserFactory.build(), User)
+        assert_type(UserFactory.create(), User)
+        assert_type(UserFactory.build_batch(2), list[User])
+        assert_type(UserFactory.create_batch(2), list[User])
+        self.assertEqual(UserFactory.create().name, "John Doe")
+
+    def test_dict_factory(self) -> None:
+        class Pet(factory.DictFactory):
+            species = "dog"
+            name = "rover"
+
+        self.assertTrue(isinstance(Pet.build(), dict))
+        self.assertTrue(isinstance(Pet.create(), dict))
+
+    def test_list_factory(self) -> None:
+        self.assertTrue(isinstance(factory.ListFactory.build(), list))
+        self.assertTrue(isinstance(factory.ListFactory.create(), list))

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ python =
 [testenv]
 deps =
     mypy
+    typing_extensions
     alchemy: SQLAlchemy
     mongo: mongoengine
     mongo: mongomock


### PR DESCRIPTION
Works on top of https://github.com/FactoryBoy/factory_boy/pull/1060 

The mypy extension kinda assumes that this type is already there. Adding the templating parameters fixes it and allows to remove type ignores adopted so far.