### PR TITLE
Export types per PEP 561

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,10 @@ doc =
     sphinx_rtd_theme
     sphinxcontrib-spelling
 
+[options.package_data]
+factory =
+    py.typed
+
 [bdist_wheel]
 universal = 1
 


### PR DESCRIPTION
Basic typing support was added recently, exposing return types for
`create()` and `build()`:
https://github.com/FactoryBoy/factory_boy/pull/1059

However, because this package does not expose these types, consumers of
`factory-boy` cannot leverage the annotations!

Let's ensure that the package exports its types. It's okay for only a
subset of methods to be typed! (In other words, it's still compliant
with PEP 561 to have partial coverage).