### PR TITLE
Fixed typo in orms section document.

### DIFF
--- a/docs/orms.rst
+++ b/docs/orms.rst
@@ -209,7 +209,7 @@ Extra fields
         :param str format: The image format (as supported by PIL) (default: ``'JPEG'``)
         :param str palette: The image palette (as supported by PIL) (default: ``'RGB'``)
 
-.. note:: If the value ``None`` was passed for the :class:`FileField` field, this will
+.. note:: If the value ``None`` was passed for the :class:`ImageField` field, this will
           disable field generation:
 
 .. note:: Just as Django's :class:`django.db.models.ImageField` requires the


### PR DESCRIPTION

![factory-boy-typo](https://github.com/user-attachments/assets/a623ee30-ac47-439d-878b-84e9f4eec008)

ImageField should be used for the note block, not FileField. It was presumably a typo, so I corrected it.
