### PR TITLE
MISC: add generic parameter to SQLAlchemyModelFactory

### DIFF
--- a/factory/alchemy.py
+++ b/factory/alchemy.py
@@ -43,7 +43,7 @@ class SQLAlchemyOptions(base.FactoryOptions):
         ]
 
 
-class SQLAlchemyModelFactory(base.Factory):
+class SQLAlchemyModelFactory[T](base.Factory[T]):
     """Factory for SQLAlchemy models. """
 
     _options_class = SQLAlchemyOptions


### PR DESCRIPTION
## Problem

I get the following error from `typing_extensions` module when running `factory_boy==3.3.1`:

```
app/tests/factories/base.py:6: in <module>
    class BaseFactory[T](SQLAlchemyModelFactory[T]):
app/tests/factories/base.py:6: in <generic parameters of BaseFactory>
    class BaseFactory[T](SQLAlchemyModelFactory[T]):
/usr/local/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/typing.py:398: in inner
    return func(*args, **kwds)
/usr/local/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/typing.py:1101: in _generic_class_getitem
    _check_generic(cls, params, len(cls.__parameters__))
../../../Library/Caches/pypoetry/virtualenvs/portmon-14nbLD4B-py3.12/lib/python3.12/site-packages/typing_extensions.py:2922: in _check_generic
    raise TypeError(f"{cls} is not a generic class")
E   TypeError: <SQLAlchemyModelFactory (abstract)> is not a generic class
```

after declaring a subclass of `SQLAlchemyModelFactory` in the following way:  

```py

from factory.alchemy import SQLAlchemyModelFactory
from sqlalchemy.orm import Session


class BaseFactory[T](SQLAlchemyModelFactory[T]):
    class Meta:
        abstract = True
        sqlalchemy_session_persistence = "commit"

    @classmethod
    def inject_session(cls, session: Session) -> None:
        for subclass in cls.__subclasses__():
            subclass._meta.sqlalchemy_session_factory = lambda: session # type: ignore[attr-defined]

```

## Solution

This MR addresses this problem by explicitly making `SQLAlchemyModelFactory` a generic class using `[T]`.