### PR TITLE
Fixed comments that do not reflect the PostGenerationContext changes.

### DIFF
--- a/factory/declarations.py
+++ b/factory/declarations.py
@@ -657,7 +657,7 @@ class PostGenerationDeclaration(BaseDeclaration):
         Args:
             instance (object): the newly generated object
             step (bool): whether the object was 'built' or 'created'
-            context: a builder.PostGenerationContext containing values
+            context: a declarations.PostGenerationContext containing values
                 extracted from the containing factory's declaration
         """
         raise NotImplementedError()


### PR DESCRIPTION
In commit e19142c, the PostGenerationContext class was moved from builders.py to declarations.py with minor modifications.

```
class PostGenerationDeclaration(BaseDeclaration):
    ...
    def call(self, instance, step, context):  # pragma: no cover
        """Call this hook; no return value is expected.

        Args:
            instance (object): the newly generated object
            step (bool): whether the object was 'built' or 'created'
            context: a builder.PostGenerationContext containing values
                extracted from the containing factory's declaration
        """
        raise NotImplementedError()
```
Following the application of this commit, the call method's comments in the PostGenerationDeclaration class regarding the context parameter should update the reference from `builder.PostGenerationContext` to `declarations.PostGenerationContext`.
