### PR TITLE
Allow turning off context unrolling for post_generation decorator.

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1672,6 +1672,11 @@ When calling the factory, some arguments will be extracted for this method:
 - If a ``post`` argument is passed, it will be passed as the ``extracted`` field
 - Any argument starting with ``post__XYZ`` will be extracted, its ``post__`` prefix
   removed, and added to the kwargs passed to the post-generation hook.
+- By default kwargs are "unrolled" before running the post-generation hook.
+  This means that any lazily-evaluated constructs (e.g. a :class:`LazyFunction`)
+  will be evaluated before post-generation.
+  Unrolling can be disabled with the ``unroll_context`` decorator argument:
+  ``@post_generation(unroll_context=False)``
 
 Extracted arguments won't be passed to the :attr:`~FactoryOptions.model` class.
 

--- a/factory/helpers.py
+++ b/factory/helpers.py
@@ -113,5 +113,17 @@ def container_attribute(func):
     return declarations.ContainerAttribute(func, strict=False)
 
 
-def post_generation(fun):
-    return declarations.PostGeneration(fun)
+def post_generation(fun=None, unroll_context=True):
+    """Post-generation decorator that allows turning context unrolling on/off.
+
+    Turning off context unrolling is useful e.g. for passing a LazyFunction as
+    a post-generation keyword argument.
+    """
+    class PostGeneration(declarations.PostGeneration):
+        UNROLL_CONTEXT_BEFORE_EVALUATION = unroll_context
+
+    def post_generation_(fun):
+        return PostGeneration(fun)
+
+    # Note: fun will be None when the decorator is used with parentheses.
+    return post_generation_(fun) if fun is not None else post_generation_


### PR DESCRIPTION
In some cases, it is desired to pass lazy functions as post-generation kwargs. E.g. provide a factory.LazyFunction, that will in turn be used as a keyword argument to create_batch().

Because context unrolling is enabled for PostGeneration, this is not possible because the lazy function will be evaluated (unrolled) before calling the post-generation function.

With this PR, it is possible to disable context unrolling for post-generation, depending on the use case.