### PR TITLE
Evaluate error string lazily for performance.

### DIFF
--- a/factory/builder.py
+++ b/factory/builder.py
@@ -365,9 +365,9 @@ class Resolver:
             self.__values[name] = value
             return value
         else:
-            raise AttributeError(
+            raise errors.LazyAttributeError(
                 "The parameter %r is unknown. Evaluated attributes are %r, "
-                "definitions are %r." % (name, self.__values, self.__declarations))
+                "definitions are %r.", name, self.__values, self.__declarations)
 
     def __setattr__(self, name, value):
         """Prevent setting attributes once __init__ is done."""

--- a/factory/errors.py
+++ b/factory/errors.py
@@ -27,3 +27,17 @@ class InvalidDeclarationError(FactoryError):
     This means that the user declared 'foo__bar' without adding a declaration
     at 'foo'.
     """
+
+
+class LazyAttributeError(AttributeError):
+    """ A lazily evaluated version of AttributeError.
+
+    To be used when generating the error message is expensive.
+    """
+    def __init__(self, message, *args):
+        super().__init__()
+        self._message = message
+        self._args = args
+
+    def __str__(self):
+        return self._message % self._args


### PR DESCRIPTION
While profiling our test suite, I noticed a significant amount of time is spent in various `__repr__` methods in `factory_boy`. Most of these calls come from `Resolver.__getattr__` which uses them to generate pretty error messages. While it's nice to have user friendly error messages, this is frequently called from `deepgetattr` which dismisses the error immediately. Therefore, the actual string may be lazily evaluated only when necessary. This simple change significantly improves our test suite run time.