### PR TITLE
Add support for pypy3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
           - "3.12"
           - "3.13"
           - "pypy-3.10"
+          - "pypy-3.11"
 
     steps:
       - uses: actions/checkout@v4
@@ -40,5 +41,3 @@ jobs:
 
       - name: Run tests
         run: tox
-        env:
-          DATABASE_TYPE: ${{ matrix.database-type }}

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@ envlist =
     docs
     examples
     linkcheck
-    py{39,310,311,312,313,py39,py310}
+    py{39,310,311,312,313,py39,py310,py311}
     py{39,310,311,312,313}-django42-mongo-alchemy
-    py{py39,py310}-django42-mongo-alchemy
+    py{py310,py311}-django42-mongo-alchemy
     py{310,311,312,313}-django51-mongo-alchemy
     pypy310-django51-mongo-alchemy
     py310-djangomain-mongo-alchemy
@@ -20,6 +20,7 @@ python =
     3.12: py312
     3.13: py313
     pypy-3.10: pypy310
+    pypy-3.11: pypy311
 
 [testenv]
 deps =


### PR DESCRIPTION
* Add pypy3.11
* Removes remembrance of pypy3.9 that was discontinued back in Aug
* Removes old db environment that was no longer used