### PR TITLE
Remove the values from the AttributeError message

### DIFF
--- a/factory/builder.py
+++ b/factory/builder.py
@@ -366,8 +366,9 @@ class Resolver:
             return value
         else:
             raise AttributeError(
-                "The parameter %r is unknown. Evaluated attributes are %r, "
-                "definitions are %r." % (name, self.__values, self.__declarations))
+                "The parameter %r is unknown. Available attributes are: %s."
+                % (name, ", ".join(list(self.__declarations)))
+            )
 
     def __setattr__(self, name, value):
         """Prevent setting attributes once __init__ is done."""

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -256,9 +256,14 @@ class FactoryTestCase(unittest.TestCase):
                 model = TestObject
 
             one = declarations.LazyAttribute(lambda a: a.does_not_exist)
+            two = 2
 
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(AttributeError) as exc:
             TestObjectFactory()
+        self.assertEqual(
+            str(exc.exception),
+            "The parameter 'does_not_exist' is unknown. Available attributes are: one, two.",
+        )
 
     def test_inheritance_with_sequence(self):
         """Tests that sequence IDs are shared between parent and son."""


### PR DESCRIPTION
Fixes FactoryBoy/factory_boy#1125

Changes the `AttributeError` message in `Resolver.__getattr__` so that it does not include the object values.