### PR TITLE
fix: support nested dictionaries in deepgetattr

### DIFF
--- a/factory/declarations.py
+++ b/factory/declarations.py
@@ -166,6 +166,21 @@ class _UNSPECIFIED:
     pass
 
 
+def dictgetattr(obj, attr):
+    """A getattr that also works with dictionaries.
+
+    This will always raise an AttributeError if the attribute is not found to remain
+    compatible with `deepgetattr`'s error handling logic.
+    """
+    try:
+        return getattr(obj, attr)
+    except AttributeError as attr_error:
+        try:
+            return obj[attr]
+        except Exception as error:
+            raise attr_error from error
+
+
 def deepgetattr(obj, name, default=_UNSPECIFIED):
     """Try to retrieve the given attribute of an object, digging on '.'.
 
@@ -185,9 +200,9 @@ def deepgetattr(obj, name, default=_UNSPECIFIED):
     try:
         if '.' in name:
             attr, subname = name.split('.', 1)
-            return deepgetattr(getattr(obj, attr), subname, default)
+            return deepgetattr(dictgetattr(obj, attr), subname, default)
         else:
-            return getattr(obj, name)
+            return dictgetattr(obj, name)
     except AttributeError:
         if default is _UNSPECIFIED:
             raise

--- a/tests/test_declarations.py
+++ b/tests/test_declarations.py
@@ -42,6 +42,33 @@ class DigTestCase(unittest.TestCase):
         self.assertEqual(42, declarations.deepgetattr(obj, 'a.b.c.n.x', 42))
 
 
+class DigDictTestCase(unittest.TestCase):
+
+    def test_chaining(self):
+        """This is the same test as the `DigTestCase.test_chaining`, except it tests
+        that chaining works for dictionaries.
+        """
+        dictionary = {"n": 1}
+        dictionary["a"] = {"n": 2}
+        dictionary["a"]["b"] = {"n": 3}
+        dictionary["a"]["b"]["c"] = {"n": 4}
+
+        self.assertEqual(2, declarations.deepgetattr(dictionary, 'a')["n"])
+        with self.assertRaises(AttributeError):
+            declarations.deepgetattr(dictionary, 'b')
+        self.assertEqual(2, declarations.deepgetattr(dictionary, 'a.n'))
+        self.assertEqual(3, declarations.deepgetattr(dictionary, 'a.c', 3))
+        with self.assertRaises(AttributeError):
+            declarations.deepgetattr(dictionary, 'a.c.n')
+        with self.assertRaises(AttributeError):
+            declarations.deepgetattr(dictionary, 'a.d')
+        self.assertEqual(3, declarations.deepgetattr(dictionary, 'a.b')["n"])
+        self.assertEqual(3, declarations.deepgetattr(dictionary, 'a.b.n'))
+        self.assertEqual(4, declarations.deepgetattr(dictionary, 'a.b.c')["n"])
+        self.assertEqual(4, declarations.deepgetattr(dictionary, 'a.b.c.n'))
+        self.assertEqual(42, declarations.deepgetattr(dictionary, 'a.b.c.n.x', 42))
+
+
 class MaybeTestCase(unittest.TestCase):
     def test_init(self):
         declarations.Maybe('foo', 1, 2)

--- a/tests/test_using.py
+++ b/tests/test_using.py
@@ -567,6 +567,21 @@ class UsingFactoryTestCase(unittest.TestCase):
         test_model = TestModel2Factory()
         self.assertEqual(4, test_model.two.three)
 
+    def test_self_attribute_dict_factory(self):
+        class ChildFactory(factory.DictFactory):
+            first_name = "Bob"
+            last_name = "Dole"
+
+        class ParentFactory(factory.DictFactory):
+            child = factory.SubFactory(ChildFactory)
+            last_name = factory.SelfAttribute("child.last_name")
+
+        parent = ParentFactory()
+        self.assertEqual(
+            parent,
+            {"last_name": "Dole", "child": {"first_name": "Bob", "last_name": "Dole"}},
+        )
+
     def test_sequence_decorator(self):
         class TestObjectFactory(factory.Factory):
             class Meta:


### PR DESCRIPTION
This change should fix the case where a `SelfAttribute` attempts to access the field of a `SubFactory` that is a `DictFactory`.

closes #1134