### PR TITLE
typing: fix BaseFactory callable return type for parameterized generics. (Works in VSCode only)

### DIFF
--- a/factory/base.py
+++ b/factory/base.py
@@ -415,7 +415,7 @@ class BaseFactory(Generic[T]):
     UnknownStrategy = errors.UnknownStrategy
     UnsupportedStrategy = errors.UnsupportedStrategy
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args, **kwargs) -> T:
         """Would be called if trying to instantiate the class."""
         raise errors.FactoryError('You cannot instantiate BaseFactory')
 


### PR DESCRIPTION
Currently factory_boy only supports proper return type hints only when using the `.create()` method. This PR is meant to address the type hint that gets inferred when calling the factory class itself, and this works fine for VSCode. With this change, the concrete type provided is inferred instead of "NoReturn" which is caused by the `raise errors.FactoryError('You cannot instantiate BaseFactory')` in `BaseFactory.__new__`

This is the smallest drop-in fix that doesn't require larger changes to the codebase. One could possibly create a similar annotation on the subclass `Factory` as well, and that might be more "correct" since BaseFactory's `__new__` is technically never actually reached in typical (compliant) code as the subclass Factory is using the custom metaclass `FactoryMetaClass` which overloads the `__new__` and `__call__` functions.

Before changes:
<img width="1360" height="1353" alt="After Changes" src="https://github.com/user-attachments/assets/39160976-0562-4620-a28d-86876ecde972" />

After changes:
<img width="1415" height="1385" alt="Before Changes" src="https://github.com/user-attachments/assets/1dca4ecf-a509-4af7-8330-84c25a8edf86" />

Possible points of exploration:
- Perhaps Pycharm needs something else eg type hinting at the `__call__` level of certain classes