### PR TITLE
Fix: transformer trait override Issue 1119

### DIFF
--- a/factory/declarations.py
+++ b/factory/declarations.py
@@ -511,6 +511,8 @@ class Maybe(BaseDeclaration):
 
         self.FACTORY_BUILDER_PHASE = used_phases.pop() if used_phases else enums.BuilderPhase.ATTRIBUTE_RESOLUTION
 
+        self.CAPTURE_OVERRIDES = getattr(no_declaration, 'CAPTURE_OVERRIDES', False)
+
     def evaluate_post(self, instance, step, overrides):
         """Handle post-generation declarations"""
         decider_phase = enums.get_builder_phase(self.decider)

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -228,3 +228,31 @@ class TransformerTraitTest(TestCase):
         self.assertEqual(instance.one, "ONE")
         self.assertEqual(instance.two, "two")
         self.assertIsNone(instance.three)
+
+
+class TransformerTraitWithBaseTest(TestCase):
+    """Tests for Transformer + Trait interaction when base Transformer exists.
+
+    Regression tests for issue #1119.
+    """
+    def test_base_transformer_applies_when_trait_inactive(self):
+        """When a trait is not active, the base transformer should still apply to overrides."""
+        class TestFactory(factory.StubFactory):
+            foo = factory.Transformer(123, transform=hex)
+
+            class Params:
+                string = factory.Trait(foo=factory.Transformer(234, transform=str))
+
+        instance = TestFactory(foo=345)
+        self.assertEqual(instance.foo, "0x159")
+
+    def test_trait_transformer_applies_when_trait_active(self):
+        """When a trait is active, the trait's transformer should apply."""
+        class TestFactory(factory.StubFactory):
+            foo = factory.Transformer(123, transform=hex)
+
+            class Params:
+                string = factory.Trait(foo=factory.Transformer(234, transform=str))
+
+        instance = TestFactory(string=True, foo=345)
+        self.assertEqual(instance.foo, "345")


### PR DESCRIPTION
## Summary

Fixes #1119 - Transformer not used with trait and value override

When a field has both a base `Transformer` and a `Trait` that overrides it with another `Transformer`, user-provided overrides were bypassing the base transformer entirely when the trait was not active.

## Root Cause

When a `Trait` wraps a field, it replaces the declaration with a `Maybe` that selects between the trait's value (`yes_declaration`) and the base value (`no_declaration`). However, `Maybe` didn't propagate the `CAPTURE_OVERRIDES` attribute from its branches, so user overrides would replace the entire `Maybe` declaration instead of being forwarded to the appropriate transformer.

## Solution

Added `CAPTURE_OVERRIDES` propagation from `no_declaration` in `Maybe.__init__`. This ensures that when the trait is NOT active and there's a base `Transformer`, user overrides are properly forwarded to the base transformer.

```python
self.CAPTURE_OVERRIDES = getattr(no_declaration, 'CAPTURE_OVERRIDES', False)
```

The fix specifically uses `no_declaration` (not both branches with `or`) to preserve the existing behavior where user overrides bypass the trait's transformer when the trait IS active.

## Testing

- **2 new regression tests** added to `tests/test_transformer.py`
- **Full test suite passes** (449 tests)
- Tests cover both trait-inactive and trait-active scenarios

## Checklist

- [x] Tests pass locally
- [x] New tests added for new functionality
- [x] Follows existing code style
- [x] Linting passes
