### PR TITLE
Remove old Django versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
 
+      - name: Install system deps (only PyPy)
+        if: startsWith(matrix.python-version, 'pypy')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libjpeg-dev zlib1g-dev pkg-config
+
       - name: Install dependencies
         run: python -m pip install tox-gh-actions
 

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,6 @@ testall:
 # DOC: Run tests for the currently installed version
 # Remove cgi warning when dropping support for Django 3.2.
 test:
-	mypy --ignore-missing-imports tests/test_typing.py
 	python \
 		-b \
 		-X dev \
@@ -77,6 +76,7 @@ lint:
 	$(FLAKE8) --ignore F401 $(PACKAGE)/__init__.py
 	$(ISORT) --check-only --diff $(EXAMPLES_DIR) $(PACKAGE) $(SETUP_PY) $(TESTS_DIR)
 	check-manifest
+	mypy --ignore-missing-imports tests/test_typing.py
 
 coverage:
 	$(COVERAGE) erase

--- a/README.rst
+++ b/README.rst
@@ -404,7 +404,7 @@ To test with a specific framework version, you may use a ``tox`` target:
     $ tox -e py310
 
     # run tests inside a specific environment (django)
-    $ tox -e py310-djangomain
+    $ tox -e py310-django52
 
     # run tests inside a specific environment (alchemy)
     $ tox -e py310-alchemy

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,8 @@ ChangeLog
 ------------------
 
 - Add support for Django 5.2
+- Remove support for Django 5.0
+- Remove support for Django 5.1
 
 
 3.3.3 (2025-02-03)

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,8 +16,6 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Framework :: Django
     Framework :: Django :: 4.2
-    Framework :: Django :: 5.0
-    Framework :: Django :: 5.1
     Framework :: Django :: 5.2
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License

--- a/tests/djapp/settings.py
+++ b/tests/djapp/settings.py
@@ -30,6 +30,6 @@ MIDDLEWARE_CLASSES = ()
 
 SECRET_KEY = 'testing.'
 
-# TODO: Will be the default after Django 5.0. Remove this setting when
-# Django 5.0 is the last supported version.
+# TODO: Will be the default after Django 4.2. Remove this setting when
+# Django 4.2 is the last supported version.
 USE_TZ = True

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
     mongo: mongomock
     # mongomock imports pkg_resources, provided by setuptools.
     mongo: setuptools>=66.1.1
-    django{42,52,main}: Pillow
+    django{42,52}: Pillow
     django42: Django>=4.2,<5.0
     django52: Django>=5.2,<6
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,8 @@ envlist =
     py{39,310,311,312,313,py39,py310,py311}
     py{39,310,311,312,313}-django42-mongo-alchemy
     py{py310,py311}-django42-mongo-alchemy
-    py{310,311,312,313}-django51-mongo-alchemy
-    pypy310-django51-mongo-alchemy
-    py310-djangomain-mongo-alchemy
+    py{310,311,312,313}-django52-mongo-alchemy
+    pypy310-django52-mongo-alchemy
 
 [gh-actions]
 python =
@@ -30,17 +29,12 @@ deps =
     mongo: mongomock
     # mongomock imports pkg_resources, provided by setuptools.
     mongo: setuptools>=66.1.1
-    django{42,51,52,main}: Pillow
+    django{42,52,main}: Pillow
     django42: Django>=4.2,<5.0
-    django51: Django>=5.1,<5.2
     django52: Django>=5.2,<6
-    djangomain: Django>5.1,<6.0
 
 setenv =
     py: DJANGO_SETTINGS_MODULE=tests.djapp.settings
-
-pip_pre =
-    djangomain: true
 
 allowlist_externals = make
 commands = make test


### PR DESCRIPTION
# Depends on PR https://github.com/FactoryBoy/factory_boy/pull/1150

Removed deprecated Django framework classifiers.

Django 5.0 was removed 10 months ago
Django 5.1 was removed 2 months ago

[Source](https://endoflife.date/django)