### PR TITLE
Update CI to test against currently supported Python/Django versions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,6 +22,7 @@ jobs:
           - docs
           - examples
           - lint
+          - typecheck
 
     env:
       TOXENV: ${{ matrix.tox-environment }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,11 +19,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
           - "pypy-3.10"
           - "pypy-3.11"
 

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,6 @@ testall:
 # DOC: Run tests for the currently installed version
 # Remove cgi warning when dropping support for Django 3.2.
 test:
-	mypy --ignore-missing-imports tests/test_typing.py
 	python \
 		-b \
 		-X dev \
@@ -77,6 +76,9 @@ lint:
 	$(FLAKE8) --ignore F401 $(PACKAGE)/__init__.py
 	$(ISORT) --check-only --diff $(EXAMPLES_DIR) $(PACKAGE) $(SETUP_PY) $(TESTS_DIR)
 	check-manifest
+
+typecheck:
+	mypy --ignore-missing-imports tests/test_typing.py
 
 coverage:
 	$(COVERAGE) erase

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,16 @@ ChangeLog
 3.3.4 (unreleased)
 ------------------
 
-- Add support for Django 5.2
+*New:*
+
+  - Add support for Django 5.2
+  - Add support for Django 6.0
+  - Add support for Python 3.14
+
+*Removed:*
+
+  - Remove support for Django 5.1
+  - Remove support for Python 3.9
 
 
 3.3.3 (2025-02-03)

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,20 +16,19 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Framework :: Django
     Framework :: Django :: 4.2
-    Framework :: Django :: 5.0
-    Framework :: Django :: 5.1
     Framework :: Django :: 5.2
+    Framework :: Django :: 6.0
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Software Development :: Testing
@@ -37,7 +36,7 @@ classifiers =
 
 [options]
 packages = factory
-python_requires = >=3.8
+python_requires = >=3.10
 install_requires =
     Faker>=0.7.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,36 +5,36 @@ envlist =
     docs
     examples
     linkcheck
-    py{39,310,311,312,313,py39,py310,py311}
-    py{39,310,311,312,313}-django42-mongo-alchemy
-    py{py310,py311}-django42-mongo-alchemy
-    py{310,311,312,313}-django51-mongo-alchemy
-    pypy310-django51-mongo-alchemy
-    py310-djangomain-mongo-alchemy
+    typecheck
+    py{310,311,312,313,314,py310,py311}
+    py{310,311,312,py310,py311}-django42-mongo-alchemy
+    py{310,311,312,313,314,py310,py311}-django52-mongo-alchemy
+    py{312,313,314}-django60-mongo-alchemy
+    py{312,313,314}-djangomain-mongo-alchemy
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314
     pypy-3.10: pypy310
     pypy-3.11: pypy311
 
 [testenv]
 deps =
-    mypy
     alchemy: SQLAlchemy
     mongo: mongoengine
     mongo: mongomock
     # mongomock imports pkg_resources, provided by setuptools.
     mongo: setuptools>=66.1.1
-    django{42,51,52,main}: Pillow
+    py{310,311,312,313,314}: Pillow
     django42: Django>=4.2,<5.0
-    django51: Django>=5.1,<5.2
     django52: Django>=5.2,<6
-    djangomain: Django>5.1,<6.0
+    django60: Django>=6.0,<6.1
+    # This deliberately includes pre-releases, see `pip_pre` section below.
+    djangomain: Django>6.0,<7.0
 
 setenv =
     py: DJANGO_SETTINGS_MODULE=tests.djapp.settings
@@ -72,3 +72,10 @@ extras = dev
 
 whitelist_externals = make
 commands = make lint
+
+[testenv:typecheck]
+deps =
+    mypy
+
+whitelist_externals = make
+commands = make typecheck


### PR DESCRIPTION
This updates the tox config to run against all currently supported versions of Django and Python.

- Adds comprehensive support for Python 5.2. Previously it was only incidentally being tested via the `djangomain` tox dependency group which appears to be meant for pre-release testing given the `pip_pre=true` configuration. Now it is explicitly tested against Python 3.10-3.14
- Adds support for Django 6.0
- Adds support for Python 3.14
- Removes support for Django 5.1 (support ended Dec 2025)
- Removes support for Python 3.9 (support ended Oct 2025)
- Updates `setup.cfg` minimum Python to 3.10
- Stops running PyPy tests with `Pillow` by not installing it as a dependency for PyPy test runs (based on suggestion in #1150)
- Splits out Mypy check into it's own GitHub action run so that it doesn't run on Pypy (based on suggestion in #1150)